### PR TITLE
fix: remove system id from environment and deployment resources

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -18,7 +18,6 @@ description: |-
 ### Required
 
 - `name` (String) The name of the deployment
-- `system_id` (String) The system ID this deployment belongs to
 
 ### Optional
 

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -18,7 +18,6 @@ description: |-
 ### Required
 
 - `name` (String) The name of the environment
-- `system_id` (String) The system ID this environment belongs to
 
 ### Optional
 

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -64,10 +64,6 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"system_id": schema.StringAttribute{
-				Required:    true,
-				Description: "The system ID this deployment belongs to",
-			},
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "The name of the deployment",
@@ -302,18 +298,6 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	linkResp, err := r.workspace.Client.LinkDeploymentToSystemWithResponse(
-		ctx, r.workspace.ID.String(), data.SystemId.ValueString(), deploymentId,
-	)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to link deployment to system", err.Error())
-		return
-	}
-	if linkResp.StatusCode() != http.StatusAccepted {
-		resp.Diagnostics.AddError("Failed to link deployment to system", formatResponseError(linkResp.StatusCode(), linkResp.Body))
-		return
-	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }
 
@@ -475,7 +459,6 @@ func (r *DeploymentResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 type DeploymentResourceModel struct {
 	ID               types.String              `tfsdk:"id"`
-	SystemId         types.String              `tfsdk:"system_id"`
 	Name             types.String              `tfsdk:"name"`
 	Metadata         types.Map                 `tfsdk:"metadata"`
 	ResourceSelector types.String              `tfsdk:"resource_selector"`

--- a/internal/provider/deployment_resource_test.go
+++ b/internal/provider/deployment_resource_test.go
@@ -72,7 +72,6 @@ resource "ctrlplane_job_agent" "test" {
 }
 
 resource "ctrlplane_deployment" "test" {
-  system_id = ctrlplane_system.test.id
   name      = %q
   metadata = {
     key = %q

--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -116,18 +116,6 @@ func (r *EnvironmentResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	linkResp, err := r.workspace.Client.LinkEnvironmentToSystemWithResponse(
-		ctx, workspaceId.String(), data.SystemId.ValueString(), envId,
-	)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to link environment to system", err.Error())
-		return
-	}
-	if linkResp.StatusCode() != http.StatusAccepted {
-		resp.Diagnostics.AddError("Failed to link environment to system", formatResponseError(linkResp.StatusCode(), linkResp.Body))
-		return
-	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }
 
@@ -238,10 +226,6 @@ func (r *EnvironmentResource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional:    true,
 				Description: "The description of the environment",
 			},
-			"system_id": schema.StringAttribute{
-				Required:    true,
-				Description: "The system ID this environment belongs to",
-			},
 			"resource_selector": schema.StringAttribute{
 				Optional:    true,
 				Description: "CEL expression used to select resources",
@@ -320,7 +304,6 @@ func (r *EnvironmentResource) Metadata(ctx context.Context, req resource.Metadat
 type EnvironmentResourceModel struct {
 	ID               types.String `tfsdk:"id"`
 	Name             types.String `tfsdk:"name"`
-	SystemId         types.String `tfsdk:"system_id"`
 	ResourceSelector types.String `tfsdk:"resource_selector"`
 	Description      types.String `tfsdk:"description"`
 	Metadata         types.Map    `tfsdk:"metadata"`

--- a/internal/provider/environment_resource_test.go
+++ b/internal/provider/environment_resource_test.go
@@ -41,11 +41,6 @@ func TestAccEnvironmentResource(t *testing.T) {
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(description),
 					),
-					statecheck.ExpectKnownValue(
-						"ctrlplane_environment.test",
-						tfjsonpath.New("system_id"),
-						knownvalue.NotNull(),
-					),
 				},
 			},
 			{
@@ -80,7 +75,6 @@ resource "ctrlplane_system" "test" {
 }
 
 resource "ctrlplane_environment" "test" {
-  system_id = ctrlplane_system.test.id
   name      = %q
   description = %q
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the required system_id field from Deployment and Environment resources.
  * Deployments and environments are no longer automatically linked to a system when created.
  * Documentation for Deployment and Environment resources updated to reflect the removal of system_id.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->