### PR TITLE
fix: reference values is an optional field

### DIFF
--- a/docs/resources/deployment_variable_value.md
+++ b/docs/resources/deployment_variable_value.md
@@ -24,14 +24,14 @@ Manages a deployment variable value override in Ctrlplane. A variable value prov
 ### Optional
 
 - `literal_value` (Dynamic) A literal value (string, number, boolean, or object). Conflicts with `reference_value`.
-- `reference_value` (Block, Optional) A reference value pointing to a property on the matched resource. Conflicts with `literal_value`. (see [below for nested schema](#nestedblock--reference_value))
+- `reference_value` (Attributes) A reference value pointing to a property on the matched resource. Conflicts with `literal_value`. (see [below for nested schema](#nestedatt--reference_value))
 - `resource_selector` (String) A CEL expression to select which resources this value applies to.
 
 ### Read-Only
 
 - `id` (String) The ID of the deployment variable value.
 
-<a id="nestedblock--reference_value"></a>
+<a id="nestedatt--reference_value"></a>
 ### Nested Schema for `reference_value`
 
 Required:

--- a/internal/provider/deployment_variable_value_resource.go
+++ b/internal/provider/deployment_variable_value_resource.go
@@ -118,9 +118,8 @@ func (r *DeploymentVariableValueResource) Schema(ctx context.Context, req resour
 				Optional:            true,
 				MarkdownDescription: "A literal value (string, number, boolean, or object). Conflicts with `reference_value`.",
 			},
-		},
-		Blocks: map[string]schema.Block{
-			"reference_value": schema.SingleNestedBlock{
+			"reference_value": schema.SingleNestedAttribute{
+				Optional:            true,
 				MarkdownDescription: "A reference value pointing to a property on the matched resource. Conflicts with `literal_value`.",
 				Attributes: map[string]schema.Attribute{
 					"reference": schema.StringAttribute{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The deployment variable's reference_value is now configured as an attribute (not a nested block) and is optional, allowing simpler, more flexible Terraform declarations.
* **Documentation**
  * Docs updated to reflect the attribute-based reference_value syntax and adjusted anchors for the updated schema description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->