### PR TITLE
feat: sleep verification provider

### DIFF
--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -134,6 +134,7 @@ Optional:
 
 - `datadog` (Block, Optional) Datadog metric provider configuration (see [below for nested schema](#nestedblock--verification--metric--datadog))
 - `failure` (Block, Optional) Failure condition (see [below for nested schema](#nestedblock--verification--metric--failure))
+- `sleep` (Block, Optional) Sleep metric provider configuration (see [below for nested schema](#nestedblock--verification--metric--sleep))
 - `success` (Block, Optional) Success condition (see [below for nested schema](#nestedblock--verification--metric--success))
 
 <a id="nestedblock--verification--metric--datadog"></a>
@@ -160,6 +161,14 @@ Optional:
 
 - `condition` (String) CEL expression to evaluate failure
 - `threshold` (Number) Consecutive failures before failing
+
+
+<a id="nestedblock--verification--metric--sleep"></a>
+### Nested Schema for `verification.metric.sleep`
+
+Optional:
+
+- `duration_seconds` (Number) Duration to sleep in seconds (1-3600, default 30)
 
 
 <a id="nestedblock--verification--metric--success"></a>

--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -800,6 +800,12 @@ type ReleaseTargetState struct {
 	LatestJob      *Job     `json:"latestJob,omitempty"`
 }
 
+// ReleaseTargetWithState defines model for ReleaseTargetWithState.
+type ReleaseTargetWithState struct {
+	ReleaseTarget ReleaseTarget      `json:"releaseTarget"`
+	State         ReleaseTargetState `json:"state"`
+}
+
 // Resource defines model for Resource.
 type Resource struct {
 	Config      map[string]interface{} `json:"config"`
@@ -1054,10 +1060,26 @@ type UpsertPolicyRequest struct {
 	Metadata map[string]string  `json:"metadata"`
 	Name     string             `json:"name"`
 	Priority int                `json:"priority"`
-	Rules    []CreatePolicyRule `json:"rules"`
+	Rules    []UpsertPolicyRule `json:"rules"`
 
 	// Selector CEL expression for matching release targets. Use "true" to match all targets.
 	Selector string `json:"selector"`
+}
+
+// UpsertPolicyRule defines model for UpsertPolicyRule.
+type UpsertPolicyRule struct {
+	AnyApproval            *AnyApprovalRule            `json:"anyApproval,omitempty"`
+	CreatedAt              *string                     `json:"createdAt,omitempty"`
+	DeploymentDependency   *DeploymentDependencyRule   `json:"deploymentDependency,omitempty"`
+	DeploymentWindow       *DeploymentWindowRule       `json:"deploymentWindow,omitempty"`
+	EnvironmentProgression *EnvironmentProgressionRule `json:"environmentProgression,omitempty"`
+	GradualRollout         *GradualRolloutRule         `json:"gradualRollout,omitempty"`
+	Id                     *string                     `json:"id,omitempty"`
+	PolicyId               *string                     `json:"policyId,omitempty"`
+	Retry                  *RetryRule                  `json:"retry,omitempty"`
+	Verification           *VerificationRule           `json:"verification,omitempty"`
+	VersionCooldown        *VersionCooldownRule        `json:"versionCooldown,omitempty"`
+	VersionSelector        *VersionSelectorRule        `json:"versionSelector,omitempty"`
 }
 
 // UpsertRelationshipRuleRequest defines model for UpsertRelationshipRuleRequest.
@@ -1405,6 +1427,21 @@ type PreviewReleaseTargetsForResourceParams struct {
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
+// GetReleaseTargetStatesJSONBody defines parameters for GetReleaseTargetStates.
+type GetReleaseTargetStatesJSONBody struct {
+	DeploymentId  string `json:"deploymentId"`
+	EnvironmentId string `json:"environmentId"`
+}
+
+// GetReleaseTargetStatesParams defines parameters for GetReleaseTargetStates.
+type GetReleaseTargetStatesParams struct {
+	// Limit Maximum number of items to return
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of items to skip
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
 // GetJobsForReleaseTargetParams defines parameters for GetJobsForReleaseTarget.
 type GetJobsForReleaseTargetParams struct {
 	// Limit Maximum number of items to return
@@ -1532,6 +1569,9 @@ type RequestRelationshipRuleUpsertJSONRequestBody = UpsertRelationshipRuleReques
 
 // PreviewReleaseTargetsForResourceJSONRequestBody defines body for PreviewReleaseTargetsForResource for application/json ContentType.
 type PreviewReleaseTargetsForResourceJSONRequestBody = ResourcePreviewRequest
+
+// GetReleaseTargetStatesJSONRequestBody defines body for GetReleaseTargetStates for application/json ContentType.
+type GetReleaseTargetStatesJSONRequestBody GetReleaseTargetStatesJSONBody
 
 // RequestResourceProviderUpsertJSONRequestBody defines body for RequestResourceProviderUpsert for application/json ContentType.
 type RequestResourceProviderUpsertJSONRequestBody = UpsertResourceProviderRequest
@@ -2668,6 +2708,11 @@ type ClientInterface interface {
 
 	PreviewReleaseTargetsForResource(ctx context.Context, workspaceId string, params *PreviewReleaseTargetsForResourceParams, body PreviewReleaseTargetsForResourceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetReleaseTargetStatesWithBody request with any body
+	GetReleaseTargetStatesWithBody(ctx context.Context, workspaceId string, params *GetReleaseTargetStatesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	GetReleaseTargetStates(ctx context.Context, workspaceId string, params *GetReleaseTargetStatesParams, body GetReleaseTargetStatesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetReleaseTargetDesiredRelease request
 	GetReleaseTargetDesiredRelease(ctx context.Context, workspaceId string, releaseTargetKey string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3531,6 +3576,30 @@ func (c *Client) PreviewReleaseTargetsForResourceWithBody(ctx context.Context, w
 
 func (c *Client) PreviewReleaseTargetsForResource(ctx context.Context, workspaceId string, params *PreviewReleaseTargetsForResourceParams, body PreviewReleaseTargetsForResourceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPreviewReleaseTargetsForResourceRequest(c.Server, workspaceId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetReleaseTargetStatesWithBody(ctx context.Context, workspaceId string, params *GetReleaseTargetStatesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReleaseTargetStatesRequestWithBody(c.Server, workspaceId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetReleaseTargetStates(ctx context.Context, workspaceId string, params *GetReleaseTargetStatesParams, body GetReleaseTargetStatesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReleaseTargetStatesRequest(c.Server, workspaceId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -6314,6 +6383,91 @@ func NewPreviewReleaseTargetsForResourceRequestWithBody(server string, workspace
 	return req, nil
 }
 
+// NewGetReleaseTargetStatesRequest calls the generic GetReleaseTargetStates builder with application/json body
+func NewGetReleaseTargetStatesRequest(server string, workspaceId string, params *GetReleaseTargetStatesParams, body GetReleaseTargetStatesJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewGetReleaseTargetStatesRequestWithBody(server, workspaceId, params, "application/json", bodyReader)
+}
+
+// NewGetReleaseTargetStatesRequestWithBody generates requests for GetReleaseTargetStates with any type of body
+func NewGetReleaseTargetStatesRequestWithBody(server string, workspaceId string, params *GetReleaseTargetStatesParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "workspaceId", runtime.ParamLocationPath, workspaceId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/workspaces/%s/release-targets/state", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "offset", runtime.ParamLocationQuery, *params.Offset); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewGetReleaseTargetDesiredReleaseRequest generates requests for GetReleaseTargetDesiredRelease
 func NewGetReleaseTargetDesiredReleaseRequest(server string, workspaceId string, releaseTargetKey string) (*http.Request, error) {
 	var err error
@@ -8141,6 +8295,11 @@ type ClientWithResponsesInterface interface {
 
 	PreviewReleaseTargetsForResourceWithResponse(ctx context.Context, workspaceId string, params *PreviewReleaseTargetsForResourceParams, body PreviewReleaseTargetsForResourceJSONRequestBody, reqEditors ...RequestEditorFn) (*PreviewReleaseTargetsForResourceResponse, error)
 
+	// GetReleaseTargetStatesWithBodyWithResponse request with any body
+	GetReleaseTargetStatesWithBodyWithResponse(ctx context.Context, workspaceId string, params *GetReleaseTargetStatesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetReleaseTargetStatesResponse, error)
+
+	GetReleaseTargetStatesWithResponse(ctx context.Context, workspaceId string, params *GetReleaseTargetStatesParams, body GetReleaseTargetStatesJSONRequestBody, reqEditors ...RequestEditorFn) (*GetReleaseTargetStatesResponse, error)
+
 	// GetReleaseTargetDesiredReleaseWithResponse request
 	GetReleaseTargetDesiredReleaseWithResponse(ctx context.Context, workspaceId string, releaseTargetKey string, reqEditors ...RequestEditorFn) (*GetReleaseTargetDesiredReleaseResponse, error)
 
@@ -9428,6 +9587,40 @@ func (r PreviewReleaseTargetsForResourceResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PreviewReleaseTargetsForResourceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetReleaseTargetStatesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Items []ReleaseTargetWithState `json:"items"`
+
+		// Limit Maximum number of items returned
+		Limit int `json:"limit"`
+
+		// Offset Number of items skipped
+		Offset int `json:"offset"`
+
+		// Total Total number of items available
+		Total int `json:"total"`
+	}
+	JSON400 *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetReleaseTargetStatesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetReleaseTargetStatesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -10762,6 +10955,23 @@ func (c *ClientWithResponses) PreviewReleaseTargetsForResourceWithResponse(ctx c
 		return nil, err
 	}
 	return ParsePreviewReleaseTargetsForResourceResponse(rsp)
+}
+
+// GetReleaseTargetStatesWithBodyWithResponse request with arbitrary body returning *GetReleaseTargetStatesResponse
+func (c *ClientWithResponses) GetReleaseTargetStatesWithBodyWithResponse(ctx context.Context, workspaceId string, params *GetReleaseTargetStatesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetReleaseTargetStatesResponse, error) {
+	rsp, err := c.GetReleaseTargetStatesWithBody(ctx, workspaceId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetReleaseTargetStatesResponse(rsp)
+}
+
+func (c *ClientWithResponses) GetReleaseTargetStatesWithResponse(ctx context.Context, workspaceId string, params *GetReleaseTargetStatesParams, body GetReleaseTargetStatesJSONRequestBody, reqEditors ...RequestEditorFn) (*GetReleaseTargetStatesResponse, error) {
+	rsp, err := c.GetReleaseTargetStates(ctx, workspaceId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetReleaseTargetStatesResponse(rsp)
 }
 
 // GetReleaseTargetDesiredReleaseWithResponse request returning *GetReleaseTargetDesiredReleaseResponse
@@ -12897,6 +13107,50 @@ func ParsePreviewReleaseTargetsForResourceResponse(rsp *http.Response) (*Preview
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			Items []ReleaseTargetPreview `json:"items"`
+
+			// Limit Maximum number of items returned
+			Limit int `json:"limit"`
+
+			// Offset Number of items skipped
+			Offset int `json:"offset"`
+
+			// Total Total number of items available
+			Total int `json:"total"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetReleaseTargetStatesResponse parses an HTTP response from a GetReleaseTargetStatesWithResponse call
+func ParseGetReleaseTargetStatesResponse(rsp *http.Response) (*GetReleaseTargetStatesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetReleaseTargetStatesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Items []ReleaseTargetWithState `json:"items"`
 
 			// Limit Maximum number of items returned
 			Limit int `json:"limit"`

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -302,6 +302,17 @@ func (r *PolicyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 											},
 										},
 									},
+									"sleep": schema.SingleNestedBlock{
+										Description: "Sleep metric provider configuration",
+										Attributes: map[string]schema.Attribute{
+											"duration_seconds": schema.Int64Attribute{
+												Optional:    true,
+												Computed:    true,
+												Description: "Duration to sleep in seconds (1-3600, default 30)",
+												Default:     int64default.StaticInt64(30),
+											},
+										},
+									},
 									"datadog": schema.SingleNestedBlock{
 										Description: "Datadog metric provider configuration",
 										Attributes: map[string]schema.Attribute{
@@ -829,7 +840,12 @@ type PolicyVerificationMetric struct {
 	Count    types.Int64                  `tfsdk:"count"`
 	Success  *PolicyVerificationCondition `tfsdk:"success"`
 	Failure  *PolicyVerificationCondition `tfsdk:"failure"`
+	Sleep    *PolicySleepProvider         `tfsdk:"sleep"`
 	Datadog  *PolicyDatadogProvider       `tfsdk:"datadog"`
+}
+
+type PolicySleepProvider struct {
+	DurationSeconds types.Int64 `tfsdk:"duration_seconds"`
 }
 
 type PolicyVerificationCondition struct {
@@ -1113,8 +1129,14 @@ func policyVerificationMetricFromModel(model PolicyVerificationMetric) (api.Veri
 	if model.Success == nil {
 		return api.VerificationMetricSpec{}, fmt.Errorf("metric success block is required")
 	}
-	if model.Datadog == nil {
-		return api.VerificationMetricSpec{}, fmt.Errorf("metric datadog block is required")
+
+	hasSleep := model.Sleep != nil
+	hasDatadog := model.Datadog != nil
+	if !hasSleep && !hasDatadog {
+		return api.VerificationMetricSpec{}, fmt.Errorf("exactly one of sleep or datadog provider block is required")
+	}
+	if hasSleep && hasDatadog {
+		return api.VerificationMetricSpec{}, fmt.Errorf("only one of sleep or datadog provider block can be set")
 	}
 
 	intervalSeconds, err := parseDurationSeconds(model.Interval)
@@ -1132,7 +1154,12 @@ func policyVerificationMetricFromModel(model PolicyVerificationMetric) (api.Veri
 		return api.VerificationMetricSpec{}, fmt.Errorf("success condition must be set")
 	}
 
-	provider, err := policyDatadogProviderFromModel(*model.Datadog)
+	var provider api.MetricProvider
+	if hasSleep {
+		provider, err = policySleepProviderFromModel(*model.Sleep)
+	} else {
+		provider, err = policyDatadogProviderFromModel(*model.Datadog)
+	}
 	if err != nil {
 		return api.VerificationMetricSpec{}, err
 	}
@@ -1159,6 +1186,22 @@ func policyVerificationMetricFromModel(model PolicyVerificationMetric) (api.Veri
 	}
 
 	return spec, nil
+}
+
+func policySleepProviderFromModel(model PolicySleepProvider) (api.MetricProvider, error) {
+	durationSeconds := int32(defaultInt64(model.DurationSeconds, 30))
+
+	sleepProvider := api.SleepMetricProvider{
+		Type:            api.Sleep,
+		DurationSeconds: durationSeconds,
+	}
+
+	var provider api.MetricProvider
+	if err := provider.FromSleepMetricProvider(sleepProvider); err != nil {
+		return api.MetricProvider{}, err
+	}
+
+	return provider, nil
 }
 
 func policyDatadogProviderFromModel(model PolicyDatadogProvider) (api.MetricProvider, error) {
@@ -1631,11 +1674,6 @@ func policyVerificationRuleToModel(rule *api.VerificationRule) (PolicyVerificati
 }
 
 func policyVerificationMetricToModel(metric api.VerificationMetricSpec) (PolicyVerificationMetric, error) {
-	provider, err := metric.Provider.AsDatadogMetricProvider()
-	if err != nil {
-		return PolicyVerificationMetric{}, err
-	}
-
 	model := PolicyVerificationMetric{
 		Name:     types.StringValue(metric.Name),
 		Interval: types.StringValue((time.Duration(metric.IntervalSeconds) * time.Second).String()),
@@ -1645,7 +1683,8 @@ func policyVerificationMetricToModel(metric api.VerificationMetricSpec) (PolicyV
 			Threshold: types.Int64Null(),
 		},
 		Failure: nil,
-		Datadog: &PolicyDatadogProvider{},
+		Sleep:   nil,
+		Datadog: nil,
 	}
 
 	if metric.SuccessThreshold != nil {
@@ -1664,28 +1703,41 @@ func policyVerificationMetricToModel(metric api.VerificationMetricSpec) (PolicyV
 		}
 	}
 
+	if sleepProvider, err := metric.Provider.AsSleepMetricProvider(); err == nil {
+		model.Sleep = &PolicySleepProvider{
+			DurationSeconds: types.Int64Value(int64(sleepProvider.DurationSeconds)),
+		}
+		return model, nil
+	}
+
+	datadogProvider, err := metric.Provider.AsDatadogMetricProvider()
+	if err != nil {
+		return PolicyVerificationMetric{}, fmt.Errorf("unsupported metric provider type: %w", err)
+	}
+
+	model.Datadog = &PolicyDatadogProvider{}
 	model.Datadog.Site = types.StringNull()
-	if provider.Site != nil {
-		model.Datadog.Site = types.StringValue(*provider.Site)
+	if datadogProvider.Site != nil {
+		model.Datadog.Site = types.StringValue(*datadogProvider.Site)
 	}
 	model.Datadog.Interval = types.StringNull()
-	if provider.IntervalSeconds != nil {
-		model.Datadog.Interval = types.StringValue((time.Duration(*provider.IntervalSeconds) * time.Second).String())
+	if datadogProvider.IntervalSeconds != nil {
+		model.Datadog.Interval = types.StringValue((time.Duration(*datadogProvider.IntervalSeconds) * time.Second).String())
 	}
 	model.Datadog.Queries = types.MapNull(types.StringType)
-	if len(provider.Queries) > 0 {
-		result, _ := types.MapValueFrom(context.Background(), types.StringType, provider.Queries)
+	if len(datadogProvider.Queries) > 0 {
+		result, _ := types.MapValueFrom(context.Background(), types.StringType, datadogProvider.Queries)
 		model.Datadog.Queries = result
 	}
-	model.Datadog.ApiKey = types.StringValue(provider.ApiKey)
-	model.Datadog.AppKey = types.StringValue(provider.AppKey)
+	model.Datadog.ApiKey = types.StringValue(datadogProvider.ApiKey)
+	model.Datadog.AppKey = types.StringValue(datadogProvider.AppKey)
 	model.Datadog.Aggregator = types.StringNull()
-	if provider.Aggregator != nil {
-		model.Datadog.Aggregator = types.StringValue(string(*provider.Aggregator))
+	if datadogProvider.Aggregator != nil {
+		model.Datadog.Aggregator = types.StringValue(string(*datadogProvider.Aggregator))
 	}
 	model.Datadog.Formula = types.StringNull()
-	if provider.Formula != nil {
-		model.Datadog.Formula = types.StringValue(*provider.Formula)
+	if datadogProvider.Formula != nil {
+		model.Datadog.Formula = types.StringValue(*datadogProvider.Formula)
 	}
 
 	return model, nil

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -1189,11 +1189,14 @@ func policyVerificationMetricFromModel(model PolicyVerificationMetric) (api.Veri
 }
 
 func policySleepProviderFromModel(model PolicySleepProvider) (api.MetricProvider, error) {
-	durationSeconds := int32(defaultInt64(model.DurationSeconds, 30))
+	durationSeconds := defaultInt64(model.DurationSeconds, 30)
+	if durationSeconds < 1 || durationSeconds > 3600 {
+		return api.MetricProvider{}, fmt.Errorf("sleep duration_seconds must be between 1 and 3600, got %d", durationSeconds)
+	}
 
 	sleepProvider := api.SleepMetricProvider{
 		Type:            api.Sleep,
-		DurationSeconds: durationSeconds,
+		DurationSeconds: int32(durationSeconds),
 	}
 
 	var provider api.MetricProvider
@@ -1703,16 +1706,35 @@ func policyVerificationMetricToModel(metric api.VerificationMetricSpec) (PolicyV
 		}
 	}
 
-	if sleepProvider, err := metric.Provider.AsSleepMetricProvider(); err == nil {
+	providerJSON, err := json.Marshal(metric.Provider)
+	if err != nil {
+		return PolicyVerificationMetric{}, fmt.Errorf("failed to marshal metric provider: %w", err)
+	}
+	var discriminator struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(providerJSON, &discriminator); err != nil {
+		return PolicyVerificationMetric{}, fmt.Errorf("failed to read metric provider type: %w", err)
+	}
+
+	switch discriminator.Type {
+	case "sleep":
+		sleepProvider, err := metric.Provider.AsSleepMetricProvider()
+		if err != nil {
+			return PolicyVerificationMetric{}, fmt.Errorf("failed to parse sleep provider: %w", err)
+		}
 		model.Sleep = &PolicySleepProvider{
 			DurationSeconds: types.Int64Value(int64(sleepProvider.DurationSeconds)),
 		}
 		return model, nil
+	case "datadog":
+	default:
+		return PolicyVerificationMetric{}, fmt.Errorf("unsupported metric provider type: %q", discriminator.Type)
 	}
 
 	datadogProvider, err := metric.Provider.AsDatadogMetricProvider()
 	if err != nil {
-		return PolicyVerificationMetric{}, fmt.Errorf("unsupported metric provider type: %w", err)
+		return PolicyVerificationMetric{}, fmt.Errorf("failed to parse datadog provider: %w", err)
 	}
 
 	model.Datadog = &PolicyDatadogProvider{}

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -97,6 +97,75 @@ func TestAccPolicyResource(t *testing.T) {
 	})
 }
 
+func TestAccPolicyResourceSleepVerification(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-policy-sleep-%d", time.Now().UnixNano())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyResourceSleepVerificationConfig(name, 60),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ctrlplane_policy.test_sleep",
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"ctrlplane_policy.test_sleep",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(name),
+					),
+					statecheck.ExpectKnownValue(
+						"ctrlplane_policy.test_sleep",
+						tfjsonpath.New("verification").AtSliceIndex(0).AtMapKey("trigger_on"),
+						knownvalue.StringExact("jobSuccess"),
+					),
+				},
+			},
+			{
+				Config: testAccPolicyResourceSleepVerificationConfig(name, 120),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ctrlplane_policy.test_sleep",
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccPolicyResourceSleepVerificationConfig(name string, durationSeconds int) string {
+	return fmt.Sprintf(`
+%s
+resource "ctrlplane_policy" "test_sleep" {
+  name     = %q
+  selector = "true"
+
+  verification {
+    trigger_on = "jobSuccess"
+
+    metric {
+      name     = "wait-for-stabilization"
+      interval = "30s"
+      count    = 1
+
+      success {
+        condition = "result.ok == true"
+      }
+
+      sleep {
+        duration_seconds = %d
+      }
+    }
+  }
+}
+`, testAccProviderConfig(), name, durationSeconds)
+}
+
 func testAccPolicyResourceConfig(name, description string, priority int, enabled bool) string {
 	return fmt.Sprintf(`
 %s


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sleep-based metric provider for policy verification with configurable duration (seconds); sleep and Datadog provider blocks are mutually exclusive.
  * Added a new API to retrieve release target states (GetReleaseTargetStates).

* **Tests**
  * Added acceptance tests covering sleep-based verification flows.

* **Documentation**
  * Updated policy docs to include the new verification.metric.sleep block and duration_seconds field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->