### PR TITLE
feat: add webhook_url and trigger_run_on_change to terraform_cloud block

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -76,6 +76,7 @@ Optional:
 - `organization` (String) Terraform Cloud organization name
 - `template` (String) Terraform Cloud workspace template
 - `token` (String, Sensitive) Terraform Cloud API token
+- `trigger_run_on_change` (Boolean) Whether to create a TFC run on dispatch. When false, only the workspace and variables are synced. Defaults to true.
 
 
 <a id="nestedblock--job_agent--test_runner"></a>

--- a/docs/resources/job_agent.md
+++ b/docs/resources/job_agent.md
@@ -69,11 +69,11 @@ Required:
 - `address` (String) Terraform Cloud address (e.g. https://app.terraform.io)
 - `organization` (String) Terraform Cloud organization name
 - `template` (String) Terraform Cloud workspace template
-- `token` (String, Sensitive) Terraform Cloud API token
 - `webhook_url` (String) The ctrlplane API endpoint for TFC webhook notifications (e.g. https://ctrlplane.example.com/api/tfe/webhook)
 
 Optional:
 
+- `token` (String, Sensitive) Terraform Cloud API token
 - `trigger_run_on_change` (Boolean) Whether to create a TFC run on dispatch. When false, only the workspace and variables are synced. Defaults to true.
 
 

--- a/docs/resources/job_agent.md
+++ b/docs/resources/job_agent.md
@@ -70,6 +70,11 @@ Required:
 - `organization` (String) Terraform Cloud organization name
 - `template` (String) Terraform Cloud workspace template
 - `token` (String, Sensitive) Terraform Cloud API token
+- `webhook_url` (String) The ctrlplane API endpoint for TFC webhook notifications (e.g. https://ctrlplane.example.com/api/tfe/webhook)
+
+Optional:
+
+- `trigger_run_on_change` (Boolean) Whether to create a TFC run on dispatch. When false, only the workspace and variables are synced. Defaults to true.
 
 
 <a id="nestedblock--test_runner"></a>

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -378,6 +378,11 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 		if len(dep.JobAgentConfig) > 0 {
 			setDeploymentJobAgentBlocksFromConfig(&jobAgent, dep.JobAgentConfig, blockType)
 		}
+		if len(priorAgents) > 0 && jobAgent.TerraformCloud != nil && priorAgents[0].TerraformCloud != nil {
+			if !priorAgents[0].TerraformCloud.Token.IsNull() {
+				jobAgent.TerraformCloud.Token = priorAgents[0].TerraformCloud.Token
+			}
+		}
 		agentList, diags := types.ListValueFrom(ctx, deploymentJobAgentObjectType, []DeploymentJobAgentModel{jobAgent})
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
@@ -605,6 +610,12 @@ func deploymentJobAgentModelsFromAPI(agents []api.DeploymentJobAgent, priorAgent
 				blockType = deploymentJobAgentBlockType(priorAgents[i])
 			}
 			setDeploymentJobAgentBlocksFromConfig(&model, agent.Config, blockType)
+		}
+		// Preserve sensitive token from prior state since the API won't return it.
+		if i < len(priorAgents) && model.TerraformCloud != nil && priorAgents[i].TerraformCloud != nil {
+			if !priorAgents[i].TerraformCloud.Token.IsNull() {
+				model.TerraformCloud.Token = priorAgents[i].TerraformCloud.Token
+			}
 		}
 		result = append(result, model)
 	}

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -732,6 +732,9 @@ func setDeploymentJobAgentBlocksFromConfig(ja *DeploymentJobAgentModel, config m
 		return
 	}
 
+	// agentType is derived from prior state; it will be "" after `terraform import`
+	// (no prior state exists). In that case no block is populated — the next
+	// plan/apply will reconcile from the user's HCL config.
 	switch agentType {
 	case "argocd":
 		ja.ArgoCD = &DeploymentJobAgentArgoCDModel{

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -348,11 +348,7 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	if dep.JobAgents != nil && len(*dep.JobAgents) > 0 {
-		agentModels, err := r.deploymentJobAgentModelsFromAPI(ctx, *dep.JobAgents)
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to read deployment", err.Error())
-			return
-		}
+		agentModels := r.deploymentJobAgentModelsFromAPI(ctx, *dep.JobAgents)
 		agentList, diags := types.ListValueFrom(ctx, deploymentJobAgentObjectType, agentModels)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
@@ -576,9 +572,9 @@ func deploymentJobAgentsFromModel(agents []DeploymentJobAgentModel) *[]api.Deplo
 	return &result
 }
 
-func (r *DeploymentResource) deploymentJobAgentModelsFromAPI(ctx context.Context, agents []api.DeploymentJobAgent) ([]DeploymentJobAgentModel, error) {
+func (r *DeploymentResource) deploymentJobAgentModelsFromAPI(ctx context.Context, agents []api.DeploymentJobAgent) []DeploymentJobAgentModel {
 	if len(agents) == 0 {
-		return nil, nil
+		return nil
 	}
 	result := make([]DeploymentJobAgentModel, 0, len(agents))
 	for _, agent := range agents {
@@ -600,7 +596,7 @@ func (r *DeploymentResource) deploymentJobAgentModelsFromAPI(ctx context.Context
 		}
 		result = append(result, model)
 	}
-	return result, nil
+	return result
 }
 
 func (r *DeploymentResource) lookupJobAgentType(ctx context.Context, jobAgentID string) string {

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -166,6 +166,10 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 									Description: "Terraform Cloud API token",
 									Sensitive:   true,
 								},
+								"trigger_run_on_change": schema.BoolAttribute{
+									Optional:    true,
+									Description: "Whether to create a TFC run on dispatch. When false, only the workspace and variables are synced. Defaults to true.",
+								},
 							},
 						},
 						"test_runner": schema.SingleNestedBlock{
@@ -344,7 +348,11 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	if dep.JobAgents != nil && len(*dep.JobAgents) > 0 {
-		agentModels := deploymentJobAgentModelsFromAPI(*dep.JobAgents)
+		agentModels, err := r.deploymentJobAgentModelsFromAPI(ctx, *dep.JobAgents)
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to read deployment", err.Error())
+			return
+		}
 		agentList, diags := types.ListValueFrom(ctx, deploymentJobAgentObjectType, agentModels)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
@@ -352,6 +360,7 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 		}
 		data.JobAgent = agentList
 	} else if dep.JobAgentId != nil {
+		agentType := r.lookupJobAgentType(ctx, *dep.JobAgentId)
 		jobAgent := DeploymentJobAgentModel{
 			Id:             types.StringValue(*dep.JobAgentId),
 			Priority:       types.Int64Null(),
@@ -362,7 +371,7 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 			TestRunner:     nil,
 		}
 		if len(dep.JobAgentConfig) > 0 {
-			setDeploymentJobAgentBlocksFromConfig(&jobAgent, dep.JobAgentConfig)
+			setDeploymentJobAgentBlocksFromConfig(&jobAgent, dep.JobAgentConfig, agentType)
 		}
 		agentList, diags := types.ListValueFrom(ctx, deploymentJobAgentObjectType, []DeploymentJobAgentModel{jobAgent})
 		resp.Diagnostics.Append(diags...)
@@ -479,10 +488,11 @@ var deploymentJobAgentGitHubAttrTypes = map[string]attr.Type{
 }
 
 var deploymentJobAgentTFCAttrTypes = map[string]attr.Type{
-	"address":      types.StringType,
-	"organization": types.StringType,
-	"template":     types.StringType,
-	"token":        types.StringType,
+	"address":               types.StringType,
+	"organization":          types.StringType,
+	"template":              types.StringType,
+	"token":                 types.StringType,
+	"trigger_run_on_change": types.BoolType,
 }
 
 var deploymentJobAgentTestRunnerAttrTypes = map[string]attr.Type{
@@ -528,10 +538,11 @@ type DeploymentJobAgentGitHubModel struct {
 }
 
 type DeploymentJobAgentTFCModel struct {
-	Address      types.String `tfsdk:"address"`
-	Organization types.String `tfsdk:"organization"`
-	Template     types.String `tfsdk:"template"`
-	Token        types.String `tfsdk:"token"`
+	Address            types.String `tfsdk:"address"`
+	Organization       types.String `tfsdk:"organization"`
+	Template           types.String `tfsdk:"template"`
+	Token              types.String `tfsdk:"token"`
+	TriggerRunOnChange types.Bool   `tfsdk:"trigger_run_on_change"`
 }
 
 type DeploymentJobAgentTestRunnerModel struct {
@@ -565,9 +576,9 @@ func deploymentJobAgentsFromModel(agents []DeploymentJobAgentModel) *[]api.Deplo
 	return &result
 }
 
-func deploymentJobAgentModelsFromAPI(agents []api.DeploymentJobAgent) []DeploymentJobAgentModel {
+func (r *DeploymentResource) deploymentJobAgentModelsFromAPI(ctx context.Context, agents []api.DeploymentJobAgent) ([]DeploymentJobAgentModel, error) {
 	if len(agents) == 0 {
-		return nil
+		return nil, nil
 	}
 	result := make([]DeploymentJobAgentModel, 0, len(agents))
 	for _, agent := range agents {
@@ -584,11 +595,35 @@ func deploymentJobAgentModelsFromAPI(agents []api.DeploymentJobAgent) []Deployme
 			model.Selector = types.StringValue(agent.Selector)
 		}
 		if len(agent.Config) > 0 {
-			setDeploymentJobAgentBlocksFromConfig(&model, agent.Config)
+			agentType := r.lookupJobAgentType(ctx, agent.Ref)
+			setDeploymentJobAgentBlocksFromConfig(&model, agent.Config, agentType)
 		}
 		result = append(result, model)
 	}
-	return result
+	return result, nil
+}
+
+func (r *DeploymentResource) lookupJobAgentType(ctx context.Context, jobAgentID string) string {
+	resp, err := r.workspace.Client.GetJobAgentWithResponse(ctx, r.workspace.ID.String(), jobAgentID)
+	if err != nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return ""
+	}
+	return normalizeJobAgentType(resp.JSON200.Type)
+}
+
+func normalizeJobAgentType(apiType string) string {
+	switch apiType {
+	case "argo-cd":
+		return "argocd"
+	case "github-app":
+		return "github"
+	case "tfe":
+		return "terraform_cloud"
+	case "test-runner":
+		return "test_runner"
+	default:
+		return apiType
+	}
 }
 
 func countDeploymentJobAgentBlocks(ja DeploymentJobAgentModel) int {
@@ -660,6 +695,9 @@ func deploymentJobAgentConfigFromModel(ja DeploymentJobAgentModel) *map[string]i
 		if !ja.TerraformCloud.Token.IsNull() && !ja.TerraformCloud.Token.IsUnknown() && ja.TerraformCloud.Token.ValueString() != "" {
 			cfg["token"] = ja.TerraformCloud.Token.ValueString()
 		}
+		if !ja.TerraformCloud.TriggerRunOnChange.IsNull() && !ja.TerraformCloud.TriggerRunOnChange.IsUnknown() {
+			cfg["triggerRunOnChange"] = ja.TerraformCloud.TriggerRunOnChange.ValueBool()
+		}
 		if len(cfg) == 0 {
 			return nil
 		}
@@ -684,7 +722,7 @@ func deploymentJobAgentConfigFromModel(ja DeploymentJobAgentModel) *map[string]i
 	}
 }
 
-func setDeploymentJobAgentBlocksFromConfig(ja *DeploymentJobAgentModel, config map[string]interface{}) {
+func setDeploymentJobAgentBlocksFromConfig(ja *DeploymentJobAgentModel, config map[string]interface{}, agentType string) {
 	ja.ArgoCD = nil
 	ja.GitHub = nil
 	ja.TerraformCloud = nil
@@ -694,7 +732,14 @@ func setDeploymentJobAgentBlocksFromConfig(ja *DeploymentJobAgentModel, config m
 		return
 	}
 
-	if configHasAny(config, "installationId", "workflowId", "owner", "repo") {
+	switch agentType {
+	case "argocd":
+		ja.ArgoCD = &DeploymentJobAgentArgoCDModel{
+			ApiKey:    stringValueOrNull(config["apiKey"]),
+			ServerUrl: stringValueOrNull(config["serverUrl"]),
+			Template:  stringValueOrNull(config["template"]),
+		}
+	case "github":
 		github := DeploymentJobAgentGitHubModel{
 			InstallationId: types.Int64Null(),
 			Owner:          types.StringNull(),
@@ -718,29 +763,15 @@ func setDeploymentJobAgentBlocksFromConfig(ja *DeploymentJobAgentModel, config m
 			github.Ref = types.StringValue(fmt.Sprint(v))
 		}
 		ja.GitHub = &github
-		return
-	}
-
-	if configHasAny(config, "apiKey", "serverUrl", "template") {
-		ja.ArgoCD = &DeploymentJobAgentArgoCDModel{
-			ApiKey:    stringValueOrNull(config["apiKey"]),
-			ServerUrl: stringValueOrNull(config["serverUrl"]),
-			Template:  stringValueOrNull(config["template"]),
-		}
-		return
-	}
-
-	if configHasAny(config, "address", "organization", "template", "token") {
+	case "terraform_cloud":
 		ja.TerraformCloud = &DeploymentJobAgentTFCModel{
-			Address:      stringValueOrNull(config["address"]),
-			Organization: stringValueOrNull(config["organization"]),
-			Template:     stringValueOrNull(config["template"]),
-			Token:        stringValueOrNull(config["token"]),
+			Address:            stringValueOrNull(config["address"]),
+			Organization:       stringValueOrNull(config["organization"]),
+			Template:           stringValueOrNull(config["template"]),
+			Token:              stringValueOrNull(config["token"]),
+			TriggerRunOnChange: boolValueOrNull(config["triggerRunOnChange"]),
 		}
-		return
-	}
-
-	if configHasAny(config, "delaySeconds", "message", "status") {
+	case "test_runner":
 		testRunner := DeploymentJobAgentTestRunnerModel{
 			DelaySeconds: types.Int64Null(),
 			Message:      types.StringNull(),
@@ -759,24 +790,21 @@ func setDeploymentJobAgentBlocksFromConfig(ja *DeploymentJobAgentModel, config m
 	}
 }
 
-func configHasAny(config map[string]interface{}, keys ...string) bool {
-	for _, key := range keys {
-		if _, ok := config[key]; ok {
-			return true
-		}
-	}
-	return false
-}
-
 func stringValueOrNull(value interface{}) types.String {
 	if value == nil {
 		return types.StringNull()
 	}
-	str := fmt.Sprint(value)
-	if str == "" {
-		return types.StringNull()
+	return types.StringValue(fmt.Sprint(value))
+}
+
+func boolValueOrNull(value interface{}) types.Bool {
+	if value == nil {
+		return types.BoolNull()
 	}
-	return types.StringValue(str)
+	if b, ok := value.(bool); ok {
+		return types.BoolValue(b)
+	}
+	return types.BoolNull()
 }
 
 func stringInterfaceMapPointer(value types.Map) *map[string]interface{} {

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -350,7 +350,10 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	// Extract prior state agents to preserve block type across read.
 	var priorAgents []DeploymentJobAgentModel
 	if !data.JobAgent.IsNull() && !data.JobAgent.IsUnknown() {
-		data.JobAgent.ElementsAs(ctx, &priorAgents, false)
+		resp.Diagnostics.Append(data.JobAgent.ElementsAs(ctx, &priorAgents, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if dep.JobAgents != nil && len(*dep.JobAgents) > 0 {

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -347,8 +347,14 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 		data.ResourceSelector = types.StringNull()
 	}
 
+	// Extract prior state agents to preserve block type across read.
+	var priorAgents []DeploymentJobAgentModel
+	if !data.JobAgent.IsNull() && !data.JobAgent.IsUnknown() {
+		data.JobAgent.ElementsAs(ctx, &priorAgents, false)
+	}
+
 	if dep.JobAgents != nil && len(*dep.JobAgents) > 0 {
-		agentModels := r.deploymentJobAgentModelsFromAPI(ctx, *dep.JobAgents)
+		agentModels := deploymentJobAgentModelsFromAPI(*dep.JobAgents, priorAgents)
 		agentList, diags := types.ListValueFrom(ctx, deploymentJobAgentObjectType, agentModels)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
@@ -356,7 +362,10 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 		}
 		data.JobAgent = agentList
 	} else if dep.JobAgentId != nil {
-		agentType := r.lookupJobAgentType(ctx, *dep.JobAgentId)
+		var blockType string
+		if len(priorAgents) > 0 {
+			blockType = deploymentJobAgentBlockType(priorAgents[0])
+		}
 		jobAgent := DeploymentJobAgentModel{
 			Id:             types.StringValue(*dep.JobAgentId),
 			Priority:       types.Int64Null(),
@@ -367,7 +376,7 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 			TestRunner:     nil,
 		}
 		if len(dep.JobAgentConfig) > 0 {
-			setDeploymentJobAgentBlocksFromConfig(&jobAgent, dep.JobAgentConfig, agentType)
+			setDeploymentJobAgentBlocksFromConfig(&jobAgent, dep.JobAgentConfig, blockType)
 		}
 		agentList, diags := types.ListValueFrom(ctx, deploymentJobAgentObjectType, []DeploymentJobAgentModel{jobAgent})
 		resp.Diagnostics.Append(diags...)
@@ -572,12 +581,12 @@ func deploymentJobAgentsFromModel(agents []DeploymentJobAgentModel) *[]api.Deplo
 	return &result
 }
 
-func (r *DeploymentResource) deploymentJobAgentModelsFromAPI(ctx context.Context, agents []api.DeploymentJobAgent) []DeploymentJobAgentModel {
+func deploymentJobAgentModelsFromAPI(agents []api.DeploymentJobAgent, priorAgents []DeploymentJobAgentModel) []DeploymentJobAgentModel {
 	if len(agents) == 0 {
 		return nil
 	}
 	result := make([]DeploymentJobAgentModel, 0, len(agents))
-	for _, agent := range agents {
+	for i, agent := range agents {
 		model := DeploymentJobAgentModel{
 			Id:             types.StringValue(agent.Ref),
 			Priority:       types.Int64Null(),
@@ -591,34 +600,29 @@ func (r *DeploymentResource) deploymentJobAgentModelsFromAPI(ctx context.Context
 			model.Selector = types.StringValue(agent.Selector)
 		}
 		if len(agent.Config) > 0 {
-			agentType := r.lookupJobAgentType(ctx, agent.Ref)
-			setDeploymentJobAgentBlocksFromConfig(&model, agent.Config, agentType)
+			var blockType string
+			if i < len(priorAgents) {
+				blockType = deploymentJobAgentBlockType(priorAgents[i])
+			}
+			setDeploymentJobAgentBlocksFromConfig(&model, agent.Config, blockType)
 		}
 		result = append(result, model)
 	}
 	return result
 }
 
-func (r *DeploymentResource) lookupJobAgentType(ctx context.Context, jobAgentID string) string {
-	resp, err := r.workspace.Client.GetJobAgentWithResponse(ctx, r.workspace.ID.String(), jobAgentID)
-	if err != nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
-		return ""
-	}
-	return normalizeJobAgentType(resp.JSON200.Type)
-}
-
-func normalizeJobAgentType(apiType string) string {
-	switch apiType {
-	case "argo-cd":
+func deploymentJobAgentBlockType(ja DeploymentJobAgentModel) string {
+	switch {
+	case ja.ArgoCD != nil:
 		return "argocd"
-	case "github-app":
+	case ja.GitHub != nil:
 		return "github"
-	case "tfe":
+	case ja.TerraformCloud != nil:
 		return "terraform_cloud"
-	case "test-runner":
+	case ja.TestRunner != nil:
 		return "test_runner"
 	default:
-		return apiType
+		return ""
 	}
 }
 

--- a/internal/provider/deployment_resource_unit_test.go
+++ b/internal/provider/deployment_resource_unit_test.go
@@ -1,0 +1,131 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSetDeploymentJobAgentBlocksFromConfig_WithType(t *testing.T) {
+	config := map[string]interface{}{
+		"template":           "my-template",
+		"triggerRunOnChange": true,
+	}
+
+	var model DeploymentJobAgentModel
+	setDeploymentJobAgentBlocksFromConfig(&model, config, "terraform_cloud")
+
+	if model.TerraformCloud == nil {
+		t.Fatal("expected TerraformCloud block to be set")
+	}
+	if model.TerraformCloud.Template.ValueString() != "my-template" {
+		t.Errorf("expected template 'my-template', got %q", model.TerraformCloud.Template.ValueString())
+	}
+	if model.TerraformCloud.TriggerRunOnChange.ValueBool() != true {
+		t.Errorf("expected trigger_run_on_change true, got %v", model.TerraformCloud.TriggerRunOnChange.ValueBool())
+	}
+	if model.ArgoCD != nil {
+		t.Error("expected ArgoCD to be nil")
+	}
+}
+
+func TestDeploymentJobAgentBlockType(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    DeploymentJobAgentModel
+		expected string
+	}{
+		{
+			name:     "argocd",
+			model:    DeploymentJobAgentModel{ArgoCD: &DeploymentJobAgentArgoCDModel{}},
+			expected: "argocd",
+		},
+		{
+			name:     "github",
+			model:    DeploymentJobAgentModel{GitHub: &DeploymentJobAgentGitHubModel{}},
+			expected: "github",
+		},
+		{
+			name:     "terraform_cloud",
+			model:    DeploymentJobAgentModel{TerraformCloud: &DeploymentJobAgentTFCModel{}},
+			expected: "terraform_cloud",
+		},
+		{
+			name:     "test_runner",
+			model:    DeploymentJobAgentModel{TestRunner: &DeploymentJobAgentTestRunnerModel{}},
+			expected: "test_runner",
+		},
+		{
+			name:     "empty",
+			model:    DeploymentJobAgentModel{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deploymentJobAgentBlockType(tt.model)
+			if got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+// TestImportThenApplyReadCycle simulates the full terraform import lifecycle:
+//
+// Step 1 (import): No prior state → agentType is "" → blocks stay nil.
+// Step 2 (apply):  User's HCL config writes the block to state.
+// Step 3 (read):   Prior state now has the block → agentType is derived → config populates correctly.
+//
+// This verifies that even though import produces empty blocks, the subsequent
+// apply+read cycle recovers the correct state.
+func TestImportThenApplyReadCycle(t *testing.T) {
+	apiConfig := map[string]interface{}{
+		"template":           "my-template",
+		"triggerRunOnChange": true,
+	}
+
+	// Step 1: Import — no prior state, agentType is ""
+	var afterImport DeploymentJobAgentModel
+	setDeploymentJobAgentBlocksFromConfig(&afterImport, apiConfig, "")
+
+	if afterImport.TerraformCloud != nil {
+		t.Fatal("step 1 (import): expected TerraformCloud to be nil with empty agentType")
+	}
+
+	// Step 2: Apply — user's HCL config writes terraform_cloud block to state.
+	// (Simulated: the plan uses HCL config, not the API read.)
+	afterApply := DeploymentJobAgentModel{
+		Id: types.StringValue("agent-123"),
+		TerraformCloud: &DeploymentJobAgentTFCModel{
+			Template:           types.StringValue("my-template"),
+			TriggerRunOnChange: types.BoolValue(true),
+		},
+	}
+
+	// Step 3: Next read — prior state (afterApply) provides the block type.
+	blockType := deploymentJobAgentBlockType(afterApply)
+	if blockType != "terraform_cloud" {
+		t.Fatalf("step 3 (read): expected block type 'terraform_cloud', got %q", blockType)
+	}
+
+	var afterRead DeploymentJobAgentModel
+	setDeploymentJobAgentBlocksFromConfig(&afterRead, apiConfig, blockType)
+
+	if afterRead.TerraformCloud == nil {
+		t.Fatal("step 3 (read): expected TerraformCloud to be populated")
+	}
+	if afterRead.TerraformCloud.Template.ValueString() != "my-template" {
+		t.Errorf("step 3 (read): expected template 'my-template', got %q", afterRead.TerraformCloud.Template.ValueString())
+	}
+	if afterRead.TerraformCloud.TriggerRunOnChange.ValueBool() != true {
+		t.Errorf("step 3 (read): expected trigger_run_on_change true, got %v", afterRead.TerraformCloud.TriggerRunOnChange.ValueBool())
+	}
+	if afterRead.ArgoCD != nil {
+		t.Error("step 3 (read): ArgoCD should be nil — template must not match argocd")
+	}
+}

--- a/internal/provider/deployment_resource_unit_test.go
+++ b/internal/provider/deployment_resource_unit_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"testing"
 
+	"github.com/ctrlplanedev/terraform-provider-ctrlplane/internal/api"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -72,6 +73,72 @@ func TestDeploymentJobAgentBlockType(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, got)
 			}
 		})
+	}
+}
+
+func TestDeploymentJobAgentModelsFromAPI_PreservesToken(t *testing.T) {
+	// The API never returns sensitive token values. Verify that the token
+	// from prior state is preserved after reading back from the API.
+	apiAgents := []api.DeploymentJobAgent{
+		{
+			Ref:    "agent-1",
+			Config: api.JobAgentConfig{"address": "https://tfe.example.com", "organization": "my-org"},
+		},
+	}
+
+	priorAgents := []DeploymentJobAgentModel{
+		{
+			Id: types.StringValue("agent-1"),
+			TerraformCloud: &DeploymentJobAgentTFCModel{
+				Address:      types.StringValue("https://tfe.example.com"),
+				Organization: types.StringValue("my-org"),
+				Token:        types.StringValue("secret-token"),
+			},
+		},
+	}
+
+	result := deploymentJobAgentModelsFromAPI(apiAgents, priorAgents)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(result))
+	}
+	if result[0].TerraformCloud == nil {
+		t.Fatal("expected TerraformCloud block to be set")
+	}
+	if result[0].TerraformCloud.Token.ValueString() != "secret-token" {
+		t.Errorf("expected token to be preserved as 'secret-token', got %q", result[0].TerraformCloud.Token.ValueString())
+	}
+}
+
+func TestDeploymentJobAgentModelsFromAPI_NullTokenStaysNull(t *testing.T) {
+	// When prior state has no token (null), read should also produce null.
+	apiAgents := []api.DeploymentJobAgent{
+		{
+			Ref:    "agent-1",
+			Config: api.JobAgentConfig{"address": "https://tfe.example.com"},
+		},
+	}
+
+	priorAgents := []DeploymentJobAgentModel{
+		{
+			Id: types.StringValue("agent-1"),
+			TerraformCloud: &DeploymentJobAgentTFCModel{
+				Address: types.StringValue("https://tfe.example.com"),
+				Token:   types.StringNull(),
+			},
+		},
+	}
+
+	result := deploymentJobAgentModelsFromAPI(apiAgents, priorAgents)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(result))
+	}
+	if result[0].TerraformCloud == nil {
+		t.Fatal("expected TerraformCloud block to be set")
+	}
+	if !result[0].TerraformCloud.Token.IsNull() {
+		t.Errorf("expected token to remain null, got %q", result[0].TerraformCloud.Token.ValueString())
 	}
 }
 

--- a/internal/provider/job_agent_resource.go
+++ b/internal/provider/job_agent_resource.go
@@ -335,7 +335,18 @@ func (r *JobAgentResource) Read(ctx context.Context, req resource.ReadRequest, r
 		data.Metadata = stringMapValue(&jobAgent.Metadata)
 	}
 
+	// Preserve sensitive fields that the API doesn't return.
+	var priorToken types.String
+	if len(data.TerraformCloud) > 0 {
+		priorToken = data.TerraformCloud[0].Token
+	}
+
 	setJobAgentBlocksFromAPI(&data, jobAgent.Type, jobAgent.Config)
+
+	// Restore token from prior state since the API never returns it.
+	if len(data.TerraformCloud) > 0 && !priorToken.IsNull() {
+		data.TerraformCloud[0].Token = priorToken
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -518,8 +529,10 @@ func jobAgentConfigFromModel(data JobAgentResourceModel) (string, *map[string]in
 			"address":      tfc.Address.ValueString(),
 			"organization": tfc.Organization.ValueString(),
 			"template":     tfc.Template.ValueString(),
-			"token":        tfc.Token.ValueString(),
 			"webhookUrl":   tfc.WebhookUrl.ValueString(),
+		}
+		if !tfc.Token.IsNull() && !tfc.Token.IsUnknown() && tfc.Token.ValueString() != "" {
+			cfg["token"] = tfc.Token.ValueString()
 		}
 		if !tfc.TriggerRunOnChange.IsNull() && !tfc.TriggerRunOnChange.IsUnknown() {
 			cfg["triggerRunOnChange"] = tfc.TriggerRunOnChange.ValueBool()
@@ -571,6 +584,7 @@ func setJobAgentBlocksFromAPI(data *JobAgentResourceModel, jobType string, confi
 			Address:            stringValueOrNull(config["address"]),
 			Organization:       stringValueOrNull(config["organization"]),
 			Template:           stringValueOrNull(config["template"]),
+			Token:              types.StringNull(),
 			WebhookUrl:         stringValueOrNull(config["webhookUrl"]),
 			TriggerRunOnChange: boolValueOrNull(config["triggerRunOnChange"]),
 		}

--- a/internal/provider/job_agent_resource.go
+++ b/internal/provider/job_agent_resource.go
@@ -160,6 +160,14 @@ func (r *JobAgentResource) Schema(ctx context.Context, req resource.SchemaReques
 							Description: "Terraform Cloud API token",
 							Sensitive:   true,
 						},
+						"webhook_url": schema.StringAttribute{
+							Required:    true,
+							Description: "The ctrlplane API endpoint for TFC webhook notifications (e.g. https://ctrlplane.example.com/api/tfe/webhook)",
+						},
+						"trigger_run_on_change": schema.BoolAttribute{
+							Optional:    true,
+							Description: "Whether to create a TFC run on dispatch. When false, only the workspace and variables are synced. Defaults to true.",
+						},
 					},
 				},
 			},
@@ -441,10 +449,12 @@ type JobAgentGitHubModel struct {
 }
 
 type JobAgentTFCModel struct {
-	Address      types.String `tfsdk:"address"`
-	Organization types.String `tfsdk:"organization"`
-	Template     types.String `tfsdk:"template"`
-	Token        types.String `tfsdk:"token"`
+	Address            types.String `tfsdk:"address"`
+	Organization       types.String `tfsdk:"organization"`
+	Template           types.String `tfsdk:"template"`
+	Token              types.String `tfsdk:"token"`
+	WebhookUrl         types.String `tfsdk:"webhook_url"`
+	TriggerRunOnChange types.Bool   `tfsdk:"trigger_run_on_change"`
 }
 
 type JobAgentTestRunnerModel struct {
@@ -509,6 +519,10 @@ func jobAgentConfigFromModel(data JobAgentResourceModel) (string, *map[string]in
 			"organization": tfc.Organization.ValueString(),
 			"template":     tfc.Template.ValueString(),
 			"token":        tfc.Token.ValueString(),
+			"webhookUrl":   tfc.WebhookUrl.ValueString(),
+		}
+		if !tfc.TriggerRunOnChange.IsNull() && !tfc.TriggerRunOnChange.IsUnknown() {
+			cfg["triggerRunOnChange"] = tfc.TriggerRunOnChange.ValueBool()
 		}
 		return "tfe", &cfg, nil
 	case len(data.TestRunner) > 0:
@@ -553,14 +567,18 @@ func setJobAgentBlocksFromAPI(data *JobAgentResourceModel, jobType string, confi
 		}
 		data.GitHub = []JobAgentGitHubModel{github}
 	case "tfe":
-		data.TerraformCloud = []JobAgentTFCModel{
-			{
-				Address:      types.StringValue(fmt.Sprint(config["address"])),
-				Organization: types.StringValue(fmt.Sprint(config["organization"])),
-				Template:     types.StringValue(fmt.Sprint(config["template"])),
-				Token:        types.StringValue(fmt.Sprint(config["token"])),
-			},
+		tfc := JobAgentTFCModel{
+			Address:            types.StringValue(fmt.Sprint(config["address"])),
+			Organization:       types.StringValue(fmt.Sprint(config["organization"])),
+			Template:           types.StringValue(fmt.Sprint(config["template"])),
+			Token:              types.StringValue(fmt.Sprint(config["token"])),
+			WebhookUrl:         types.StringValue(fmt.Sprint(config["webhookUrl"])),
+			TriggerRunOnChange: types.BoolNull(),
 		}
+		if v, ok := config["triggerRunOnChange"].(bool); ok {
+			tfc.TriggerRunOnChange = types.BoolValue(v)
+		}
+		data.TerraformCloud = []JobAgentTFCModel{tfc}
 	case "test-runner":
 		testRunner := JobAgentTestRunnerModel{
 			DelaySeconds: types.Int64Null(),

--- a/internal/provider/job_agent_resource.go
+++ b/internal/provider/job_agent_resource.go
@@ -156,7 +156,7 @@ func (r *JobAgentResource) Schema(ctx context.Context, req resource.SchemaReques
 							Description: "Terraform Cloud workspace template",
 						},
 						"token": schema.StringAttribute{
-							Required:    true,
+							Optional:    true,
 							Description: "Terraform Cloud API token",
 							Sensitive:   true,
 						},
@@ -568,15 +568,11 @@ func setJobAgentBlocksFromAPI(data *JobAgentResourceModel, jobType string, confi
 		data.GitHub = []JobAgentGitHubModel{github}
 	case "tfe":
 		tfc := JobAgentTFCModel{
-			Address:            types.StringValue(fmt.Sprint(config["address"])),
-			Organization:       types.StringValue(fmt.Sprint(config["organization"])),
-			Template:           types.StringValue(fmt.Sprint(config["template"])),
-			Token:              types.StringValue(fmt.Sprint(config["token"])),
-			WebhookUrl:         types.StringValue(fmt.Sprint(config["webhookUrl"])),
-			TriggerRunOnChange: types.BoolNull(),
-		}
-		if v, ok := config["triggerRunOnChange"].(bool); ok {
-			tfc.TriggerRunOnChange = types.BoolValue(v)
+			Address:            stringValueOrNull(config["address"]),
+			Organization:       stringValueOrNull(config["organization"]),
+			Template:           stringValueOrNull(config["template"]),
+			WebhookUrl:         stringValueOrNull(config["webhookUrl"]),
+			TriggerRunOnChange: boolValueOrNull(config["triggerRunOnChange"]),
 		}
 		data.TerraformCloud = []JobAgentTFCModel{tfc}
 	case "test-runner":


### PR DESCRIPTION
## Summary

Adds `webhook_url` (required) and `trigger_run_on_change` (optional) to the `terraform_cloud` job agent block, enabling webhook-based TFC status tracking.

```hcl
terraform_cloud {
  address               = "https://app.terraform.io"
  organization          = "your-org"
  token                 = var.tfc_token
  template              = file("workspace-template.yaml")
  webhook_url           = "https://ctrlplane.example.com/api/tfe/webhook"
  trigger_run_on_change = false
}
```

Depends on #31 (`use-string-cel`) merging first.

`go vet` passes
Provider builds and runs against local ctrlplane instance
Docs regenerated via `make generate`
E2E tested: `terraform apply` creates job agent with webhook fields, workspace-engine reads them correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional trigger_run_on_change toggle for Terraform Cloud integration (defaults to true).
  * Added required webhook_url for Terraform Cloud webhook notifications.
  * Made the Terraform Cloud token optional in configuration and preserved token across state/read cycles when present.

* **Documentation**
  * Updated Terraform Cloud job agent docs to describe the new fields and defaults.

* **Tests**
  * Added unit tests covering Terraform Cloud job agent handling, block selection, and state/refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->