### PR TITLE
fix: workflows using the same job agent syntax as deployments

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -33,7 +33,70 @@ Manages a workflow in Ctrlplane.
 
 Required:
 
-- `config` (Map of String) Configuration for the job agent.
 - `name` (String) Name of the job agent entry.
 - `ref` (String) ID of the job agent to reference.
 - `selector` (String) CEL expression to determine if the job agent should dispatch. Use "true" to always dispatch.
+
+Optional:
+
+- `argo_workflow` (Block, Optional) Argo Workflow job agent configuration (see [below for nested schema](#nestedblock--job_agent--argo_workflow))
+- `argocd` (Block, Optional) ArgoCD job agent configuration (see [below for nested schema](#nestedblock--job_agent--argocd))
+- `github` (Block, Optional) GitHub job agent configuration (see [below for nested schema](#nestedblock--job_agent--github))
+- `terraform_cloud` (Block, Optional) Terraform Cloud job agent configuration (see [below for nested schema](#nestedblock--job_agent--terraform_cloud))
+- `test_runner` (Block, Optional) Test runner job agent configuration (see [below for nested schema](#nestedblock--job_agent--test_runner))
+
+<a id="nestedblock--job_agent--argo_workflow"></a>
+### Nested Schema for `job_agent.argo_workflow`
+
+Optional:
+
+- `api_key` (String, Sensitive) Argo Workflow API token
+- `http_insecure` (Boolean) Allow insecure HTTP connections
+- `name` (String) The name of the argo template to call
+- `server_url` (String) Argo Workflow server address
+- `template` (String) Argo Workflow application template
+- `webhook_secret` (String, Sensitive) ArgoEvents webhook secret
+
+
+<a id="nestedblock--job_agent--argocd"></a>
+### Nested Schema for `job_agent.argocd`
+
+Optional:
+
+- `api_key` (String, Sensitive) ArgoCD API token
+- `server_url` (String) ArgoCD server address
+- `template` (String) ArgoCD application template
+
+
+<a id="nestedblock--job_agent--github"></a>
+### Nested Schema for `job_agent.github`
+
+Optional:
+
+- `installation_id` (Number) GitHub app installation ID
+- `owner` (String) GitHub repository owner
+- `ref` (String) Git ref to run the workflow on
+- `repo` (String) GitHub repository name
+- `workflow_id` (Number) GitHub Actions workflow ID
+
+
+<a id="nestedblock--job_agent--terraform_cloud"></a>
+### Nested Schema for `job_agent.terraform_cloud`
+
+Optional:
+
+- `address` (String) Terraform Cloud address
+- `organization` (String) Terraform Cloud organization name
+- `template` (String) Terraform Cloud workspace template
+- `token` (String, Sensitive) Terraform Cloud API token
+- `trigger_run_on_change` (Boolean) Whether to create a TFC run on dispatch
+
+
+<a id="nestedblock--job_agent--test_runner"></a>
+### Nested Schema for `job_agent.test_runner`
+
+Optional:
+
+- `delay_seconds` (Number) Delay in seconds before resolving the job
+- `message` (String) Optional message to include in the job output
+- `status` (String) Final status to set

--- a/examples/resources/workflow/workflows.tf
+++ b/examples/resources/workflow/workflows.tf
@@ -30,14 +30,24 @@ resource "ctrlplane_workflow" "example" {
   job_agent {
     name     = "workflow-runner-1"
     ref      = ctrlplane_job_agent.runner_1.id
-    config   = { delaySeconds = "10", message = "Test runner job agent", status = "successful" }
     selector = "true"
+
+    test_runner {
+      delay_seconds = 10
+      message       = "Test runner job agent"
+      status        = "successful"
+    }
   }
 
   job_agent {
     name     = "workflow-runner-2"
     ref      = ctrlplane_job_agent.runner_2.id
-    config   = { delaySeconds = "10", message = "Test runner job agent", status = "successful" }
     selector = "true"
+
+    test_runner {
+      delay_seconds = 10
+      message       = "Test runner job agent"
+      status        = "successful"
+    }
   }
 }

--- a/internal/provider/deployment_resource.go
+++ b/internal/provider/deployment_resource.go
@@ -4,7 +4,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -94,55 +92,7 @@ func (r *DeploymentResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Description: "CEL expression to match job agents",
 			},
 		},
-		Blocks: map[string]schema.Block{
-			"argocd": schema.SingleNestedBlock{
-				Description: "ArgoCD job agent configuration",
-				Attributes: map[string]schema.Attribute{
-					"api_key":    schema.StringAttribute{Optional: true, Sensitive: true, Description: "ArgoCD API token"},
-					"server_url": schema.StringAttribute{Optional: true, Description: "ArgoCD server address"},
-					"template":   schema.StringAttribute{Optional: true, Description: "ArgoCD application template"},
-				},
-			},
-			"argo_workflow": schema.SingleNestedBlock{
-				Description: "Argo Workflow job agent configuration",
-				Attributes: map[string]schema.Attribute{
-					"api_key":        schema.StringAttribute{Optional: true, Sensitive: true, Description: "Argo Workflow API token"},
-					"server_url":     schema.StringAttribute{Optional: true, Description: "Argo Workflow server address"},
-					"template":       schema.StringAttribute{Optional: true, Description: "Argo Workflow application template"},
-					"name":           schema.StringAttribute{Optional: true, Description: "The name of the argo template to call"},
-					"webhook_secret": schema.StringAttribute{Optional: true, Sensitive: true, Description: "ArgoEvents webhook secret"},
-					"http_insecure":  schema.BoolAttribute{Optional: true, Computed: true, Description: "Allow insecure HTTP connections", Default: booldefault.StaticBool(false)},
-				},
-			},
-			"github": schema.SingleNestedBlock{
-				Description: "GitHub job agent configuration",
-				Attributes: map[string]schema.Attribute{
-					"installation_id": schema.Int64Attribute{Optional: true, Description: "GitHub app installation ID"},
-					"owner":           schema.StringAttribute{Optional: true, Description: "GitHub repository owner"},
-					"ref":             schema.StringAttribute{Optional: true, Description: "Git ref to run the workflow on"},
-					"repo":            schema.StringAttribute{Optional: true, Description: "GitHub repository name"},
-					"workflow_id":     schema.Int64Attribute{Optional: true, Description: "GitHub Actions workflow ID"},
-				},
-			},
-			"terraform_cloud": schema.SingleNestedBlock{
-				Description: "Terraform Cloud job agent configuration",
-				Attributes: map[string]schema.Attribute{
-					"address":               schema.StringAttribute{Optional: true, Description: "Terraform Cloud address"},
-					"organization":          schema.StringAttribute{Optional: true, Description: "Terraform Cloud organization name"},
-					"template":              schema.StringAttribute{Optional: true, Description: "Terraform Cloud workspace template"},
-					"token":                 schema.StringAttribute{Optional: true, Sensitive: true, Description: "Terraform Cloud API token"},
-					"trigger_run_on_change": schema.BoolAttribute{Optional: true, Description: "Whether to create a TFC run on dispatch"},
-				},
-			},
-			"test_runner": schema.SingleNestedBlock{
-				Description: "Test runner job agent configuration",
-				Attributes: map[string]schema.Attribute{
-					"delay_seconds": schema.Int64Attribute{Optional: true, Description: "Delay in seconds before resolving the job"},
-					"message":       schema.StringAttribute{Optional: true, Description: "Optional message to include in the job output"},
-					"status":        schema.StringAttribute{Optional: true, Description: "Final status to set"},
-				},
-			},
-		},
+		Blocks: jobAgentDispatchConfigBlocks(),
 	}
 }
 
@@ -153,23 +103,7 @@ func (r *DeploymentResource) ValidateConfig(ctx context.Context, req resource.Va
 		return
 	}
 
-	count := 0
-	if data.ArgoCD != nil {
-		count++
-	}
-	if data.ArgoWorkflow != nil {
-		count++
-	}
-	if data.GitHub != nil {
-		count++
-	}
-	if data.TerraformCloud != nil {
-		count++
-	}
-	if data.TestRunner != nil {
-		count++
-	}
-	if count > 1 {
+	if dispatchBlockCount(data.dispatchBlocks()) > 1 {
 		resp.Diagnostics.AddError(
 			"Invalid job agent configuration",
 			"Only one of argocd, argo_workflow, github, terraform_cloud, or test_runner can be set.",
@@ -388,119 +322,35 @@ type DeploymentResourceModel struct {
 	ResourceSelector types.String `tfsdk:"resource_selector"`
 	JobAgentSelector types.String `tfsdk:"job_agent_selector"`
 
-	ArgoCD         *DeploymentArgoCDModel       `tfsdk:"argocd"`
-	ArgoWorkflow   *DeploymentArgoWorkflowModel `tfsdk:"argo_workflow"`
-	GitHub         *DeploymentGitHubModel       `tfsdk:"github"`
-	TerraformCloud *DeploymentTFCModel          `tfsdk:"terraform_cloud"`
-	TestRunner     *DeploymentTestRunnerModel   `tfsdk:"test_runner"`
+	ArgoCD         *JobAgentDispatchArgoCDModel       `tfsdk:"argocd"`
+	ArgoWorkflow   *JobAgentDispatchArgoWorkflowModel `tfsdk:"argo_workflow"`
+	GitHub         *JobAgentDispatchGitHubModel       `tfsdk:"github"`
+	TerraformCloud *JobAgentDispatchTFCModel          `tfsdk:"terraform_cloud"`
+	TestRunner     *JobAgentDispatchTestRunnerModel   `tfsdk:"test_runner"`
 }
 
-type DeploymentArgoCDModel struct {
-	ApiKey    types.String `tfsdk:"api_key"`
-	ServerUrl types.String `tfsdk:"server_url"`
-	Template  types.String `tfsdk:"template"`
+func (m *DeploymentResourceModel) dispatchBlocks() JobAgentDispatchBlocks {
+	return JobAgentDispatchBlocks{
+		ArgoCD:         m.ArgoCD,
+		ArgoWorkflow:   m.ArgoWorkflow,
+		GitHub:         m.GitHub,
+		TerraformCloud: m.TerraformCloud,
+		TestRunner:     m.TestRunner,
+	}
 }
 
-type DeploymentArgoWorkflowModel struct {
-	ApiKey        types.String `tfsdk:"api_key"`
-	WebhookSecret types.String `tfsdk:"webhook_secret"`
-	ServerUrl     types.String `tfsdk:"server_url"`
-	Template      types.String `tfsdk:"template"`
-	Name          types.String `tfsdk:"name"`
-	HttpInsecure  types.Bool   `tfsdk:"http_insecure"`
-}
-
-type DeploymentGitHubModel struct {
-	InstallationId types.Int64  `tfsdk:"installation_id"`
-	Owner          types.String `tfsdk:"owner"`
-	Ref            types.String `tfsdk:"ref"`
-	Repo           types.String `tfsdk:"repo"`
-	WorkflowId     types.Int64  `tfsdk:"workflow_id"`
-}
-
-type DeploymentTFCModel struct {
-	Address            types.String `tfsdk:"address"`
-	Organization       types.String `tfsdk:"organization"`
-	Template           types.String `tfsdk:"template"`
-	Token              types.String `tfsdk:"token"`
-	TriggerRunOnChange types.Bool   `tfsdk:"trigger_run_on_change"`
-}
-
-type DeploymentTestRunnerModel struct {
-	DelaySeconds types.Int64  `tfsdk:"delay_seconds"`
-	Message      types.String `tfsdk:"message"`
-	Status       types.String `tfsdk:"status"`
+func (m *DeploymentResourceModel) setDispatchBlocks(b JobAgentDispatchBlocks) {
+	m.ArgoCD = b.ArgoCD
+	m.ArgoWorkflow = b.ArgoWorkflow
+	m.GitHub = b.GitHub
+	m.TerraformCloud = b.TerraformCloud
+	m.TestRunner = b.TestRunner
 }
 
 // deploymentJobAgentConfigFromModel extracts the typed block into a
 // map[string]interface{} suitable for the API's JobAgentConfig field.
 func deploymentJobAgentConfigFromModel(data *DeploymentResourceModel) *map[string]interface{} {
-	switch {
-	case data.ArgoCD != nil:
-		cfg := map[string]any{}
-		setStringIfSet(cfg, "apiKey", data.ArgoCD.ApiKey)
-		setStringIfSet(cfg, "serverUrl", data.ArgoCD.ServerUrl)
-		setStringIfSet(cfg, "template", data.ArgoCD.Template)
-		if len(cfg) == 0 {
-			return nil
-		}
-		return &cfg
-	case data.ArgoWorkflow != nil:
-		cfg := map[string]any{}
-		setStringIfSet(cfg, "apiKey", data.ArgoWorkflow.ApiKey)
-		setStringIfSet(cfg, "webhookSecret", data.ArgoWorkflow.WebhookSecret)
-		setStringIfSet(cfg, "serverUrl", data.ArgoWorkflow.ServerUrl)
-		setStringIfSet(cfg, "template", data.ArgoWorkflow.Template)
-		setStringIfSet(cfg, "name", data.ArgoWorkflow.Name)
-		if !data.ArgoWorkflow.HttpInsecure.IsNull() && !data.ArgoWorkflow.HttpInsecure.IsUnknown() {
-			cfg["httpInsecure"] = data.ArgoWorkflow.HttpInsecure.ValueBool()
-		}
-		if len(cfg) == 0 {
-			return nil
-		}
-		return &cfg
-	case data.GitHub != nil:
-		cfg := map[string]any{}
-		if !data.GitHub.InstallationId.IsNull() && !data.GitHub.InstallationId.IsUnknown() {
-			cfg["installationId"] = data.GitHub.InstallationId.ValueInt64()
-		}
-		setStringIfSet(cfg, "owner", data.GitHub.Owner)
-		setStringIfSet(cfg, "repo", data.GitHub.Repo)
-		setStringIfSet(cfg, "ref", data.GitHub.Ref)
-		if !data.GitHub.WorkflowId.IsNull() && !data.GitHub.WorkflowId.IsUnknown() {
-			cfg["workflowId"] = data.GitHub.WorkflowId.ValueInt64()
-		}
-		if len(cfg) == 0 {
-			return nil
-		}
-		return &cfg
-	case data.TerraformCloud != nil:
-		cfg := map[string]any{}
-		setStringIfSet(cfg, "address", data.TerraformCloud.Address)
-		setStringIfSet(cfg, "organization", data.TerraformCloud.Organization)
-		setStringIfSet(cfg, "template", data.TerraformCloud.Template)
-		setStringIfSet(cfg, "token", data.TerraformCloud.Token)
-		if !data.TerraformCloud.TriggerRunOnChange.IsNull() && !data.TerraformCloud.TriggerRunOnChange.IsUnknown() {
-			cfg["triggerRunOnChange"] = data.TerraformCloud.TriggerRunOnChange.ValueBool()
-		}
-		if len(cfg) == 0 {
-			return nil
-		}
-		return &cfg
-	case data.TestRunner != nil:
-		cfg := map[string]any{}
-		if !data.TestRunner.DelaySeconds.IsNull() && !data.TestRunner.DelaySeconds.IsUnknown() {
-			cfg["delaySeconds"] = data.TestRunner.DelaySeconds.ValueInt64()
-		}
-		setStringIfSet(cfg, "message", data.TestRunner.Message)
-		setStringIfSet(cfg, "status", data.TestRunner.Status)
-		if len(cfg) == 0 {
-			return nil
-		}
-		return &cfg
-	default:
-		return nil
-	}
+	return jobAgentDispatchConfigToMap(data.dispatchBlocks())
 }
 
 func setStringIfSet(cfg map[string]any, key string, val types.String) {
@@ -513,200 +363,10 @@ func setStringIfSet(cfg map[string]any, key string, val types.String) {
 // the API's JobAgentConfig map. It uses the prior state block type to decide
 // which block to populate so that reads are stable.
 func setDeploymentBlocksFromConfig(data *DeploymentResourceModel, config map[string]interface{}) {
-	blockType := deploymentBlockType(data)
-
-	// Preserve sensitive fields from prior state before clearing blocks.
-	priorArgoCD := data.ArgoCD
-	priorArgoWorkflow := data.ArgoWorkflow
-	priorTFC := data.TerraformCloud
-
-	data.ArgoCD = nil
-	data.ArgoWorkflow = nil
-	data.GitHub = nil
-	data.TerraformCloud = nil
-	data.TestRunner = nil
-
-	if len(config) == 0 {
-		return
-	}
-
-	if blockType == "" {
-		blockType = inferBlockTypeFromConfig(config)
-	}
-	if blockType == "" {
-		return
-	}
-
-	switch blockType {
-	case "argocd":
-		data.ArgoCD = &DeploymentArgoCDModel{
-			ApiKey:    stringValueOrNull(config["apiKey"]),
-			ServerUrl: stringValueOrNull(config["serverUrl"]),
-			Template:  stringValueOrNull(config["template"]),
-		}
-		if data.ArgoCD.ApiKey.IsNull() && priorArgoCD != nil && !priorArgoCD.ApiKey.IsNull() {
-			data.ArgoCD.ApiKey = priorArgoCD.ApiKey
-		}
-	case "argo_workflow":
-		data.ArgoWorkflow = &DeploymentArgoWorkflowModel{
-			ApiKey:        stringValueOrNull(config["apiKey"]),
-			WebhookSecret: stringValueOrNull(config["webhookSecret"]),
-			ServerUrl:     stringValueOrNull(config["serverUrl"]),
-			Template:      stringValueOrNull(config["template"]),
-			Name:          stringValueOrNull(config["name"]),
-			HttpInsecure:  boolValueOrNull(config["httpInsecure"]),
-		}
-		if data.ArgoWorkflow.ApiKey.IsNull() && priorArgoWorkflow != nil && !priorArgoWorkflow.ApiKey.IsNull() {
-			data.ArgoWorkflow.ApiKey = priorArgoWorkflow.ApiKey
-		}
-		if data.ArgoWorkflow.WebhookSecret.IsNull() && priorArgoWorkflow != nil && !priorArgoWorkflow.WebhookSecret.IsNull() {
-			data.ArgoWorkflow.WebhookSecret = priorArgoWorkflow.WebhookSecret
-		}
-	case "github":
-		gh := DeploymentGitHubModel{
-			InstallationId: types.Int64Null(),
-			Owner:          types.StringNull(),
-			Ref:            types.StringNull(),
-			Repo:           types.StringNull(),
-			WorkflowId:     types.Int64Null(),
-		}
-		if v, ok := config["installationId"]; ok && v != nil {
-			gh.InstallationId = types.Int64Value(toInt64(v))
-		}
-		if v, ok := config["owner"]; ok && v != nil && fmt.Sprint(v) != "" {
-			gh.Owner = types.StringValue(fmt.Sprint(v))
-		}
-		if v, ok := config["repo"]; ok && v != nil && fmt.Sprint(v) != "" {
-			gh.Repo = types.StringValue(fmt.Sprint(v))
-		}
-		if v, ok := config["ref"]; ok && v != nil && fmt.Sprint(v) != "" {
-			gh.Ref = types.StringValue(fmt.Sprint(v))
-		}
-		if v, ok := config["workflowId"]; ok && v != nil {
-			gh.WorkflowId = types.Int64Value(toInt64(v))
-		}
-		data.GitHub = &gh
-	case "terraform_cloud":
-		data.TerraformCloud = &DeploymentTFCModel{
-			Address:            stringValueOrNull(config["address"]),
-			Organization:       stringValueOrNull(config["organization"]),
-			Template:           stringValueOrNull(config["template"]),
-			Token:              stringValueOrNull(config["token"]),
-			TriggerRunOnChange: boolValueOrNull(config["triggerRunOnChange"]),
-		}
-		if data.TerraformCloud.Token.IsNull() && priorTFC != nil && !priorTFC.Token.IsNull() {
-			data.TerraformCloud.Token = priorTFC.Token
-		}
-	case "test_runner":
-		tr := DeploymentTestRunnerModel{
-			DelaySeconds: types.Int64Null(),
-			Message:      types.StringNull(),
-			Status:       types.StringNull(),
-		}
-		if v, ok := config["delaySeconds"]; ok && v != nil {
-			tr.DelaySeconds = types.Int64Value(toInt64(v))
-		}
-		if v, ok := config["message"]; ok && v != nil && fmt.Sprint(v) != "" {
-			tr.Message = types.StringValue(fmt.Sprint(v))
-		}
-		if v, ok := config["status"]; ok && v != nil && fmt.Sprint(v) != "" {
-			tr.Status = types.StringValue(fmt.Sprint(v))
-		}
-		data.TestRunner = &tr
-	}
-}
-
-type argoCDConfig struct {
-	ApiKey    string `json:"apiKey"`
-	ServerUrl string `json:"serverUrl"`
-	Template  string `json:"template"`
-}
-
-type argoWorkflowConfig struct {
-	ApiKey        string `json:"apiKey"`
-	WebhookSecret string `json:"webhookSecret"`
-	ServerUrl     string `json:"serverUrl"`
-	Template      string `json:"template"`
-	Name          string `json:"name"`
-	HttpInsecure  *bool  `json:"httpInsecure"`
-}
-
-type githubConfig struct {
-	InstallationId *int64 `json:"installationId"`
-	Owner          string `json:"owner"`
-	Ref            string `json:"ref"`
-	Repo           string `json:"repo"`
-	WorkflowId     *int64 `json:"workflowId"`
-}
-
-type terraformCloudConfig struct {
-	Address            string `json:"address"`
-	Organization       string `json:"organization"`
-	Template           string `json:"template"`
-	Token              string `json:"token"`
-	TriggerRunOnChange *bool  `json:"triggerRunOnChange"`
-}
-
-type testRunnerConfig struct {
-	DelaySeconds *int64 `json:"delaySeconds"`
-	Message      string `json:"message"`
-	Status       string `json:"status"`
-}
-
-func inferBlockTypeFromConfig(config map[string]interface{}) string {
-	data, err := json.Marshal(config)
-	if err != nil {
-		return ""
-	}
-
-	var gh githubConfig
-	_ = json.Unmarshal(data, &gh)
-	if gh.Owner != "" || gh.Repo != "" || gh.InstallationId != nil || gh.WorkflowId != nil {
-		return "github"
-	}
-
-	var tfc terraformCloudConfig
-	_ = json.Unmarshal(data, &tfc)
-	if tfc.Organization != "" || tfc.Address != "" || tfc.TriggerRunOnChange != nil {
-		return "terraform_cloud"
-	}
-
-	var tr testRunnerConfig
-	_ = json.Unmarshal(data, &tr)
-	if tr.DelaySeconds != nil || tr.Status != "" {
-		return "test_runner"
-	}
-
-	var aw argoWorkflowConfig
-	_ = json.Unmarshal(data, &aw)
-	if aw.WebhookSecret != "" || aw.HttpInsecure != nil || aw.Name != "" {
-		return "argo_workflow"
-	}
-
-	var ac argoCDConfig
-	_ = json.Unmarshal(data, &ac)
-	if ac.ServerUrl != "" || ac.Template != "" || ac.ApiKey != "" {
-		return "argocd"
-	}
-
-	return ""
-}
-
-func deploymentBlockType(data *DeploymentResourceModel) string {
-	switch {
-	case data.ArgoCD != nil:
-		return "argocd"
-	case data.ArgoWorkflow != nil:
-		return "argo_workflow"
-	case data.GitHub != nil:
-		return "github"
-	case data.TerraformCloud != nil:
-		return "terraform_cloud"
-	case data.TestRunner != nil:
-		return "test_runner"
-	default:
-		return ""
-	}
+	prior := data.dispatchBlocks()
+	var out JobAgentDispatchBlocks
+	setJobAgentDispatchBlocksFromConfig(&prior, &out, config)
+	data.setDispatchBlocks(out)
 }
 
 func stringValueOrNull(value interface{}) types.String {

--- a/internal/provider/job_agent_dispatch_config.go
+++ b/internal/provider/job_agent_dispatch_config.go
@@ -1,0 +1,410 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type JobAgentDispatchArgoCDModel struct {
+	ApiKey    types.String `tfsdk:"api_key"`
+	ServerUrl types.String `tfsdk:"server_url"`
+	Template  types.String `tfsdk:"template"`
+}
+
+type JobAgentDispatchArgoWorkflowModel struct {
+	ApiKey        types.String `tfsdk:"api_key"`
+	WebhookSecret types.String `tfsdk:"webhook_secret"`
+	ServerUrl     types.String `tfsdk:"server_url"`
+	Template      types.String `tfsdk:"template"`
+	Name          types.String `tfsdk:"name"`
+	HttpInsecure  types.Bool   `tfsdk:"http_insecure"`
+}
+
+type JobAgentDispatchGitHubModel struct {
+	InstallationId types.Int64  `tfsdk:"installation_id"`
+	Owner          types.String `tfsdk:"owner"`
+	Ref            types.String `tfsdk:"ref"`
+	Repo           types.String `tfsdk:"repo"`
+	WorkflowId     types.Int64  `tfsdk:"workflow_id"`
+}
+
+type JobAgentDispatchTFCModel struct {
+	Address            types.String `tfsdk:"address"`
+	Organization       types.String `tfsdk:"organization"`
+	Template           types.String `tfsdk:"template"`
+	Token              types.String `tfsdk:"token"`
+	TriggerRunOnChange types.Bool   `tfsdk:"trigger_run_on_change"`
+}
+
+type JobAgentDispatchTestRunnerModel struct {
+	DelaySeconds types.Int64  `tfsdk:"delay_seconds"`
+	Message      types.String `tfsdk:"message"`
+	Status       types.String `tfsdk:"status"`
+}
+
+// JobAgentDispatchBlocks groups the typed job-agent dispatch config blocks
+// shared by deployment and workflow job_agent entries.
+type JobAgentDispatchBlocks struct {
+	ArgoCD         *JobAgentDispatchArgoCDModel
+	ArgoWorkflow   *JobAgentDispatchArgoWorkflowModel
+	GitHub         *JobAgentDispatchGitHubModel
+	TerraformCloud *JobAgentDispatchTFCModel
+	TestRunner     *JobAgentDispatchTestRunnerModel
+}
+
+// jobAgentDispatchConfigBlocks returns the schema block definitions for the
+// typed job-agent dispatch config (argocd, argo_workflow, github,
+// terraform_cloud, test_runner). These are shared between the deployment
+// resource and the workflow resource's job_agent entries.
+func jobAgentDispatchConfigBlocks() map[string]schema.Block {
+	return map[string]schema.Block{
+		"argocd": schema.SingleNestedBlock{
+			Description: "ArgoCD job agent configuration",
+			Attributes: map[string]schema.Attribute{
+				"api_key":    schema.StringAttribute{Optional: true, Sensitive: true, Description: "ArgoCD API token"},
+				"server_url": schema.StringAttribute{Optional: true, Description: "ArgoCD server address"},
+				"template":   schema.StringAttribute{Optional: true, Description: "ArgoCD application template"},
+			},
+		},
+		"argo_workflow": schema.SingleNestedBlock{
+			Description: "Argo Workflow job agent configuration",
+			Attributes: map[string]schema.Attribute{
+				"api_key":        schema.StringAttribute{Optional: true, Sensitive: true, Description: "Argo Workflow API token"},
+				"server_url":     schema.StringAttribute{Optional: true, Description: "Argo Workflow server address"},
+				"template":       schema.StringAttribute{Optional: true, Description: "Argo Workflow application template"},
+				"name":           schema.StringAttribute{Optional: true, Description: "The name of the argo template to call"},
+				"webhook_secret": schema.StringAttribute{Optional: true, Sensitive: true, Description: "ArgoEvents webhook secret"},
+				"http_insecure":  schema.BoolAttribute{Optional: true, Computed: true, Description: "Allow insecure HTTP connections", Default: booldefault.StaticBool(false)},
+			},
+		},
+		"github": schema.SingleNestedBlock{
+			Description: "GitHub job agent configuration",
+			Attributes: map[string]schema.Attribute{
+				"installation_id": schema.Int64Attribute{Optional: true, Description: "GitHub app installation ID"},
+				"owner":           schema.StringAttribute{Optional: true, Description: "GitHub repository owner"},
+				"ref":             schema.StringAttribute{Optional: true, Description: "Git ref to run the workflow on"},
+				"repo":            schema.StringAttribute{Optional: true, Description: "GitHub repository name"},
+				"workflow_id":     schema.Int64Attribute{Optional: true, Description: "GitHub Actions workflow ID"},
+			},
+		},
+		"terraform_cloud": schema.SingleNestedBlock{
+			Description: "Terraform Cloud job agent configuration",
+			Attributes: map[string]schema.Attribute{
+				"address":               schema.StringAttribute{Optional: true, Description: "Terraform Cloud address"},
+				"organization":          schema.StringAttribute{Optional: true, Description: "Terraform Cloud organization name"},
+				"template":              schema.StringAttribute{Optional: true, Description: "Terraform Cloud workspace template"},
+				"token":                 schema.StringAttribute{Optional: true, Sensitive: true, Description: "Terraform Cloud API token"},
+				"trigger_run_on_change": schema.BoolAttribute{Optional: true, Description: "Whether to create a TFC run on dispatch"},
+			},
+		},
+		"test_runner": schema.SingleNestedBlock{
+			Description: "Test runner job agent configuration",
+			Attributes: map[string]schema.Attribute{
+				"delay_seconds": schema.Int64Attribute{Optional: true, Description: "Delay in seconds before resolving the job"},
+				"message":       schema.StringAttribute{Optional: true, Description: "Optional message to include in the job output"},
+				"status":        schema.StringAttribute{Optional: true, Description: "Final status to set"},
+			},
+		},
+	}
+}
+
+// jobAgentDispatchConfigToMap converts the typed dispatch blocks into the
+// map[string]interface{} payload expected by the API. Returns nil when no
+// block is set or when the selected block contributes no fields.
+func jobAgentDispatchConfigToMap(b JobAgentDispatchBlocks) *map[string]interface{} {
+	switch {
+	case b.ArgoCD != nil:
+		cfg := map[string]any{}
+		setStringIfSet(cfg, "apiKey", b.ArgoCD.ApiKey)
+		setStringIfSet(cfg, "serverUrl", b.ArgoCD.ServerUrl)
+		setStringIfSet(cfg, "template", b.ArgoCD.Template)
+		if len(cfg) == 0 {
+			return nil
+		}
+		return &cfg
+	case b.ArgoWorkflow != nil:
+		cfg := map[string]any{}
+		setStringIfSet(cfg, "apiKey", b.ArgoWorkflow.ApiKey)
+		setStringIfSet(cfg, "webhookSecret", b.ArgoWorkflow.WebhookSecret)
+		setStringIfSet(cfg, "serverUrl", b.ArgoWorkflow.ServerUrl)
+		setStringIfSet(cfg, "template", b.ArgoWorkflow.Template)
+		setStringIfSet(cfg, "name", b.ArgoWorkflow.Name)
+		if !b.ArgoWorkflow.HttpInsecure.IsNull() && !b.ArgoWorkflow.HttpInsecure.IsUnknown() {
+			cfg["httpInsecure"] = b.ArgoWorkflow.HttpInsecure.ValueBool()
+		}
+		if len(cfg) == 0 {
+			return nil
+		}
+		return &cfg
+	case b.GitHub != nil:
+		cfg := map[string]any{}
+		if !b.GitHub.InstallationId.IsNull() && !b.GitHub.InstallationId.IsUnknown() {
+			cfg["installationId"] = b.GitHub.InstallationId.ValueInt64()
+		}
+		setStringIfSet(cfg, "owner", b.GitHub.Owner)
+		setStringIfSet(cfg, "repo", b.GitHub.Repo)
+		setStringIfSet(cfg, "ref", b.GitHub.Ref)
+		if !b.GitHub.WorkflowId.IsNull() && !b.GitHub.WorkflowId.IsUnknown() {
+			cfg["workflowId"] = b.GitHub.WorkflowId.ValueInt64()
+		}
+		if len(cfg) == 0 {
+			return nil
+		}
+		return &cfg
+	case b.TerraformCloud != nil:
+		cfg := map[string]any{}
+		setStringIfSet(cfg, "address", b.TerraformCloud.Address)
+		setStringIfSet(cfg, "organization", b.TerraformCloud.Organization)
+		setStringIfSet(cfg, "template", b.TerraformCloud.Template)
+		setStringIfSet(cfg, "token", b.TerraformCloud.Token)
+		if !b.TerraformCloud.TriggerRunOnChange.IsNull() && !b.TerraformCloud.TriggerRunOnChange.IsUnknown() {
+			cfg["triggerRunOnChange"] = b.TerraformCloud.TriggerRunOnChange.ValueBool()
+		}
+		if len(cfg) == 0 {
+			return nil
+		}
+		return &cfg
+	case b.TestRunner != nil:
+		cfg := map[string]any{}
+		if !b.TestRunner.DelaySeconds.IsNull() && !b.TestRunner.DelaySeconds.IsUnknown() {
+			cfg["delaySeconds"] = b.TestRunner.DelaySeconds.ValueInt64()
+		}
+		setStringIfSet(cfg, "message", b.TestRunner.Message)
+		setStringIfSet(cfg, "status", b.TestRunner.Status)
+		if len(cfg) == 0 {
+			return nil
+		}
+		return &cfg
+	default:
+		return nil
+	}
+}
+
+// dispatchBlockType returns the active block kind, or "" if no block is set.
+func dispatchBlockType(b JobAgentDispatchBlocks) string {
+	switch {
+	case b.ArgoCD != nil:
+		return "argocd"
+	case b.ArgoWorkflow != nil:
+		return "argo_workflow"
+	case b.GitHub != nil:
+		return "github"
+	case b.TerraformCloud != nil:
+		return "terraform_cloud"
+	case b.TestRunner != nil:
+		return "test_runner"
+	default:
+		return ""
+	}
+}
+
+// dispatchBlockCount returns how many typed blocks are set.
+func dispatchBlockCount(b JobAgentDispatchBlocks) int {
+	count := 0
+	if b.ArgoCD != nil {
+		count++
+	}
+	if b.ArgoWorkflow != nil {
+		count++
+	}
+	if b.GitHub != nil {
+		count++
+	}
+	if b.TerraformCloud != nil {
+		count++
+	}
+	if b.TestRunner != nil {
+		count++
+	}
+	return count
+}
+
+// setJobAgentDispatchBlocksFromConfig populates the typed dispatch blocks on
+// the model from the API's job-agent config map. The prior block values are
+// preserved for sensitive fields (API tokens, secrets) since the API does not
+// return them. The block kind is selected from `prior` when set, otherwise
+// inferred from the config payload.
+func setJobAgentDispatchBlocksFromConfig(prior, out *JobAgentDispatchBlocks, config map[string]interface{}) {
+	priorArgoCD := prior.ArgoCD
+	priorArgoWorkflow := prior.ArgoWorkflow
+	priorTFC := prior.TerraformCloud
+
+	out.ArgoCD = nil
+	out.ArgoWorkflow = nil
+	out.GitHub = nil
+	out.TerraformCloud = nil
+	out.TestRunner = nil
+
+	if len(config) == 0 {
+		return
+	}
+
+	blockType := dispatchBlockType(*prior)
+	if blockType == "" {
+		blockType = inferDispatchBlockType(config)
+	}
+	if blockType == "" {
+		return
+	}
+
+	switch blockType {
+	case "argocd":
+		out.ArgoCD = &JobAgentDispatchArgoCDModel{
+			ApiKey:    stringValueOrNull(config["apiKey"]),
+			ServerUrl: stringValueOrNull(config["serverUrl"]),
+			Template:  stringValueOrNull(config["template"]),
+		}
+		if out.ArgoCD.ApiKey.IsNull() && priorArgoCD != nil && !priorArgoCD.ApiKey.IsNull() {
+			out.ArgoCD.ApiKey = priorArgoCD.ApiKey
+		}
+	case "argo_workflow":
+		out.ArgoWorkflow = &JobAgentDispatchArgoWorkflowModel{
+			ApiKey:        stringValueOrNull(config["apiKey"]),
+			WebhookSecret: stringValueOrNull(config["webhookSecret"]),
+			ServerUrl:     stringValueOrNull(config["serverUrl"]),
+			Template:      stringValueOrNull(config["template"]),
+			Name:          stringValueOrNull(config["name"]),
+			HttpInsecure:  boolValueOrNull(config["httpInsecure"]),
+		}
+		if out.ArgoWorkflow.ApiKey.IsNull() && priorArgoWorkflow != nil && !priorArgoWorkflow.ApiKey.IsNull() {
+			out.ArgoWorkflow.ApiKey = priorArgoWorkflow.ApiKey
+		}
+		if out.ArgoWorkflow.WebhookSecret.IsNull() && priorArgoWorkflow != nil && !priorArgoWorkflow.WebhookSecret.IsNull() {
+			out.ArgoWorkflow.WebhookSecret = priorArgoWorkflow.WebhookSecret
+		}
+	case "github":
+		gh := JobAgentDispatchGitHubModel{
+			InstallationId: types.Int64Null(),
+			Owner:          types.StringNull(),
+			Ref:            types.StringNull(),
+			Repo:           types.StringNull(),
+			WorkflowId:     types.Int64Null(),
+		}
+		if v, ok := config["installationId"]; ok && v != nil {
+			gh.InstallationId = types.Int64Value(toInt64(v))
+		}
+		if v, ok := config["owner"]; ok && v != nil && fmt.Sprint(v) != "" {
+			gh.Owner = types.StringValue(fmt.Sprint(v))
+		}
+		if v, ok := config["repo"]; ok && v != nil && fmt.Sprint(v) != "" {
+			gh.Repo = types.StringValue(fmt.Sprint(v))
+		}
+		if v, ok := config["ref"]; ok && v != nil && fmt.Sprint(v) != "" {
+			gh.Ref = types.StringValue(fmt.Sprint(v))
+		}
+		if v, ok := config["workflowId"]; ok && v != nil {
+			gh.WorkflowId = types.Int64Value(toInt64(v))
+		}
+		out.GitHub = &gh
+	case "terraform_cloud":
+		out.TerraformCloud = &JobAgentDispatchTFCModel{
+			Address:            stringValueOrNull(config["address"]),
+			Organization:       stringValueOrNull(config["organization"]),
+			Template:           stringValueOrNull(config["template"]),
+			Token:              stringValueOrNull(config["token"]),
+			TriggerRunOnChange: boolValueOrNull(config["triggerRunOnChange"]),
+		}
+		if out.TerraformCloud.Token.IsNull() && priorTFC != nil && !priorTFC.Token.IsNull() {
+			out.TerraformCloud.Token = priorTFC.Token
+		}
+	case "test_runner":
+		tr := JobAgentDispatchTestRunnerModel{
+			DelaySeconds: types.Int64Null(),
+			Message:      types.StringNull(),
+			Status:       types.StringNull(),
+		}
+		if v, ok := config["delaySeconds"]; ok && v != nil {
+			tr.DelaySeconds = types.Int64Value(toInt64(v))
+		}
+		if v, ok := config["message"]; ok && v != nil && fmt.Sprint(v) != "" {
+			tr.Message = types.StringValue(fmt.Sprint(v))
+		}
+		if v, ok := config["status"]; ok && v != nil && fmt.Sprint(v) != "" {
+			tr.Status = types.StringValue(fmt.Sprint(v))
+		}
+		out.TestRunner = &tr
+	}
+}
+
+type argoCDConfig struct {
+	ApiKey    string `json:"apiKey"`
+	ServerUrl string `json:"serverUrl"`
+	Template  string `json:"template"`
+}
+
+type argoWorkflowConfig struct {
+	ApiKey        string `json:"apiKey"`
+	WebhookSecret string `json:"webhookSecret"`
+	ServerUrl     string `json:"serverUrl"`
+	Template      string `json:"template"`
+	Name          string `json:"name"`
+	HttpInsecure  *bool  `json:"httpInsecure"`
+}
+
+type githubConfig struct {
+	InstallationId *int64 `json:"installationId"`
+	Owner          string `json:"owner"`
+	Ref            string `json:"ref"`
+	Repo           string `json:"repo"`
+	WorkflowId     *int64 `json:"workflowId"`
+}
+
+type terraformCloudConfig struct {
+	Address            string `json:"address"`
+	Organization       string `json:"organization"`
+	Template           string `json:"template"`
+	Token              string `json:"token"`
+	TriggerRunOnChange *bool  `json:"triggerRunOnChange"`
+}
+
+type testRunnerConfig struct {
+	DelaySeconds *int64 `json:"delaySeconds"`
+	Message      string `json:"message"`
+	Status       string `json:"status"`
+}
+
+func inferDispatchBlockType(config map[string]interface{}) string {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return ""
+	}
+
+	var gh githubConfig
+	_ = json.Unmarshal(data, &gh)
+	if gh.Owner != "" || gh.Repo != "" || gh.InstallationId != nil || gh.WorkflowId != nil {
+		return "github"
+	}
+
+	var tfc terraformCloudConfig
+	_ = json.Unmarshal(data, &tfc)
+	if tfc.Organization != "" || tfc.Address != "" || tfc.TriggerRunOnChange != nil {
+		return "terraform_cloud"
+	}
+
+	var tr testRunnerConfig
+	_ = json.Unmarshal(data, &tr)
+	if tr.DelaySeconds != nil || tr.Status != "" {
+		return "test_runner"
+	}
+
+	var aw argoWorkflowConfig
+	_ = json.Unmarshal(data, &aw)
+	if aw.WebhookSecret != "" || aw.HttpInsecure != nil || aw.Name != "" {
+		return "argo_workflow"
+	}
+
+	var ac argoCDConfig
+	_ = json.Unmarshal(data, &ac)
+	if ac.ServerUrl != "" || ac.Template != "" || ac.ApiKey != "" {
+		return "argocd"
+	}
+
+	return ""
+}

--- a/internal/provider/workflow_resource.go
+++ b/internal/provider/workflow_resource.go
@@ -18,9 +18,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ resource.Resource = &WorkflowResource{}
-var _ resource.ResourceWithImportState = &WorkflowResource{}
-var _ resource.ResourceWithConfigure = &WorkflowResource{}
+var (
+	_ resource.Resource                   = &WorkflowResource{}
+	_ resource.ResourceWithImportState    = &WorkflowResource{}
+	_ resource.ResourceWithConfigure      = &WorkflowResource{}
+	_ resource.ResourceWithValidateConfig = &WorkflowResource{}
+)
 
 func NewWorkflowResource() resource.Resource {
 	return &WorkflowResource{}
@@ -40,8 +43,31 @@ type WorkflowResourceModel struct {
 type WorkflowJobAgentModel struct {
 	Name     types.String `tfsdk:"name"`
 	Ref      types.String `tfsdk:"ref"`
-	Config   types.Map    `tfsdk:"config"`
 	Selector types.String `tfsdk:"selector"`
+
+	ArgoCD         *JobAgentDispatchArgoCDModel       `tfsdk:"argocd"`
+	ArgoWorkflow   *JobAgentDispatchArgoWorkflowModel `tfsdk:"argo_workflow"`
+	GitHub         *JobAgentDispatchGitHubModel       `tfsdk:"github"`
+	TerraformCloud *JobAgentDispatchTFCModel          `tfsdk:"terraform_cloud"`
+	TestRunner     *JobAgentDispatchTestRunnerModel   `tfsdk:"test_runner"`
+}
+
+func (m *WorkflowJobAgentModel) dispatchBlocks() JobAgentDispatchBlocks {
+	return JobAgentDispatchBlocks{
+		ArgoCD:         m.ArgoCD,
+		ArgoWorkflow:   m.ArgoWorkflow,
+		GitHub:         m.GitHub,
+		TerraformCloud: m.TerraformCloud,
+		TestRunner:     m.TestRunner,
+	}
+}
+
+func (m *WorkflowJobAgentModel) setDispatchBlocks(b JobAgentDispatchBlocks) {
+	m.ArgoCD = b.ArgoCD
+	m.ArgoWorkflow = b.ArgoWorkflow
+	m.GitHub = b.GitHub
+	m.TerraformCloud = b.TerraformCloud
+	m.TestRunner = b.TestRunner
 }
 
 func (r *WorkflowResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -97,19 +123,40 @@ func (r *WorkflowResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 							Required:    true,
 							Description: "ID of the job agent to reference.",
 						},
-						"config": schema.MapAttribute{
-							Required:    true,
-							Description: "Configuration for the job agent.",
-							ElementType: types.StringType,
-						},
 						"selector": schema.StringAttribute{
 							Required:    true,
 							Description: "CEL expression to determine if the job agent should dispatch. Use \"true\" to always dispatch.",
 						},
 					},
+					Blocks: jobAgentDispatchConfigBlocks(),
 				},
 			},
 		},
+	}
+}
+
+func (r *WorkflowResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data WorkflowResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	for i, agent := range data.JobAgents {
+		count := dispatchBlockCount(agent.dispatchBlocks())
+		if count == 0 {
+			resp.Diagnostics.AddError(
+				"Invalid job agent configuration",
+				fmt.Sprintf("job_agent[%d] (%q) must set exactly one of argocd, argo_workflow, github, terraform_cloud, or test_runner.", i, agent.Name.ValueString()),
+			)
+			continue
+		}
+		if count > 1 {
+			resp.Diagnostics.AddError(
+				"Invalid job agent configuration",
+				fmt.Sprintf("job_agent[%d] (%q) may set only one of argocd, argo_workflow, github, terraform_cloud, or test_runner.", i, agent.Name.ValueString()),
+			)
+		}
 	}
 }
 
@@ -287,13 +334,11 @@ func parseWorkflowInputs(raw types.String) ([]api.WorkflowInput, error) {
 func workflowJobAgentsFromModel(agents []WorkflowJobAgentModel) []api.CreateWorkflowJobAgent {
 	result := make([]api.CreateWorkflowJobAgent, len(agents))
 	for i, a := range agents {
-		config := make(map[string]interface{})
-		if !a.Config.IsNull() && !a.Config.IsUnknown() {
-			var decoded map[string]string
-			_ = a.Config.ElementsAs(context.Background(), &decoded, false)
-			for k, v := range decoded {
-				config[k] = v
-			}
+		var config map[string]interface{}
+		if cfg := jobAgentDispatchConfigToMap(a.dispatchBlocks()); cfg != nil {
+			config = *cfg
+		} else {
+			config = map[string]interface{}{}
 		}
 		result[i] = api.CreateWorkflowJobAgent{
 			Name:     a.Name.ValueString(),
@@ -311,14 +356,26 @@ func setWorkflowModelFromAPI(data *WorkflowResourceModel, w *api.Workflow) {
 
 	data.Inputs = types.StringValue(normalizeInputsJSON(w.Inputs))
 
+	priorByName := make(map[string]WorkflowJobAgentModel, len(data.JobAgents))
+	for _, a := range data.JobAgents {
+		priorByName[a.Name.ValueString()] = a
+	}
+
 	agents := make([]WorkflowJobAgentModel, len(w.JobAgents))
 	for i, a := range w.JobAgents {
-		agents[i] = WorkflowJobAgentModel{
+		agent := WorkflowJobAgentModel{
 			Name:     types.StringValue(a.Name),
 			Ref:      types.StringValue(a.Ref),
-			Config:   interfaceMapStringValue(a.Config),
 			Selector: types.StringValue(a.Selector),
 		}
+		var prior JobAgentDispatchBlocks
+		if p, ok := priorByName[a.Name]; ok {
+			prior = p.dispatchBlocks()
+		}
+		var out JobAgentDispatchBlocks
+		setJobAgentDispatchBlocksFromConfig(&prior, &out, a.Config)
+		agent.setDispatchBlocks(out)
+		agents[i] = agent
 	}
 	data.JobAgents = agents
 }

--- a/internal/provider/workflow_resource.go
+++ b/internal/provider/workflow_resource.go
@@ -142,6 +142,7 @@ func (r *WorkflowResource) ValidateConfig(ctx context.Context, req resource.Vali
 		return
 	}
 
+	seenNames := make(map[string]int, len(data.JobAgents))
 	for i, agent := range data.JobAgents {
 		count := dispatchBlockCount(agent.dispatchBlocks())
 		if count == 0 {
@@ -157,6 +158,19 @@ func (r *WorkflowResource) ValidateConfig(ctx context.Context, req resource.Vali
 				fmt.Sprintf("job_agent[%d] (%q) may set only one of argocd, argo_workflow, github, terraform_cloud, or test_runner.", i, agent.Name.ValueString()),
 			)
 		}
+
+		if agent.Name.IsNull() || agent.Name.IsUnknown() {
+			continue
+		}
+		name := agent.Name.ValueString()
+		if prev, ok := seenNames[name]; ok {
+			resp.Diagnostics.AddError(
+				"Duplicate job agent name",
+				fmt.Sprintf("job_agent[%d] reuses name %q already used by job_agent[%d]; names must be unique within a workflow.", i, name, prev),
+			)
+			continue
+		}
+		seenNames[name] = i
 	}
 }
 

--- a/internal/provider/workflow_resource_test.go
+++ b/internal/provider/workflow_resource_test.go
@@ -75,8 +75,12 @@ resource "ctrlplane_workflow" "test" {
   job_agent {
     name     = "test-agent"
     ref      = ctrlplane_job_agent.test.id
-    config   = { "delaySeconds" = "5", "status" = "successful" }
     selector = "true"
+
+    test_runner {
+      delay_seconds = 5
+      status        = "successful"
+    }
   }
 }
 `, testAccProviderConfig(), name+"-agent", name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `job_agent` block schema with provider-specific nested block options.

* **Refactor**
  * `job_agent` configuration changed: `config` attribute removed in favor of explicit nested blocks for `argo_workflow`, `argocd`, `github`, `terraform_cloud`, and `test_runner`.
  * Reduced `job_agent` required fields to `name`, `ref`, and `selector`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->