### PR TITLE
chore: add workflow slug to tf provider

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -23,6 +23,7 @@ Manages a workflow in Ctrlplane.
 
 - `inputs` (String) JSON-encoded array of workflow input definitions.
 - `job_agent` (Block List) Job agents to dispatch when the workflow runs. (see [below for nested schema](#nestedblock--job_agent))
+- `slug` (String) URL-safe identifier unique within the workspace. Derived from name if omitted; sticky once set.
 
 ### Read-Only
 

--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -202,6 +202,11 @@ const (
 	WorkflowSelectorArrayInputTypeArray WorkflowSelectorArrayInputType = "array"
 )
 
+// Defines values for WorkflowSlugConflictResponseCode.
+const (
+	DUPLICATESLUG WorkflowSlugConflictResponseCode = "DUPLICATE_SLUG"
+)
+
 // Defines values for WorkflowStringInputType.
 const (
 	String WorkflowStringInputType = "string"
@@ -335,6 +340,9 @@ type CreateWorkflow struct {
 	Inputs    []WorkflowInput          `json:"inputs"`
 	JobAgents []CreateWorkflowJobAgent `json:"jobAgents"`
 	Name      string                   `json:"name"`
+
+	// Slug URL-safe identifier unique within the workspace. Derived from name if omitted.
+	Slug *string `json:"slug,omitempty"`
 }
 
 // CreateWorkflowJobAgent defines model for CreateWorkflowJobAgent.
@@ -552,6 +560,25 @@ type DeploymentVersionDependency struct {
 
 // DeploymentVersionStatus defines model for DeploymentVersionStatus.
 type DeploymentVersionStatus string
+
+// DeploymentVersionWithDependencies defines model for DeploymentVersionWithDependencies.
+type DeploymentVersionWithDependencies struct {
+	Config    map[string]interface{} `json:"config"`
+	CreatedAt time.Time              `json:"createdAt"`
+
+	// Dependencies Map of dependency deployment ID to its CEL version selector evaluated against that deployment's current release on the same resource.
+	Dependencies map[string]struct {
+		VersionSelector string `json:"versionSelector"`
+	} `json:"dependencies"`
+	DeploymentId   string                  `json:"deploymentId"`
+	Id             string                  `json:"id"`
+	JobAgentConfig map[string]interface{}  `json:"jobAgentConfig"`
+	Message        *string                 `json:"message,omitempty"`
+	Metadata       *map[string]string      `json:"metadata,omitempty"`
+	Name           string                  `json:"name"`
+	Status         DeploymentVersionStatus `json:"status"`
+	Tag            string                  `json:"tag"`
+}
 
 // DeploymentWindowRule defines model for DeploymentWindowRule.
 type DeploymentWindowRule struct {
@@ -1169,6 +1196,9 @@ type UpdateWorkflow struct {
 	Inputs    []WorkflowInput          `json:"inputs"`
 	JobAgents []CreateWorkflowJobAgent `json:"jobAgents"`
 	Name      string                   `json:"name"`
+
+	// Slug URL-safe identifier unique within the workspace.
+	Slug *string `json:"slug,omitempty"`
 }
 
 // UpdateWorkspaceRequest defines model for UpdateWorkspaceRequest.
@@ -1459,6 +1489,7 @@ type Workflow struct {
 	Inputs    []WorkflowInput    `json:"inputs"`
 	JobAgents []WorkflowJobAgent `json:"jobAgents"`
 	Name      string             `json:"name"`
+	Slug      string             `json:"slug"`
 }
 
 // WorkflowArrayInput defines model for WorkflowArrayInput.
@@ -1559,6 +1590,22 @@ type WorkflowSelectorArrayInputSelectorEntityType string
 
 // WorkflowSelectorArrayInputType defines model for WorkflowSelectorArrayInput.Type.
 type WorkflowSelectorArrayInputType string
+
+// WorkflowSlugConflictResponse defines model for WorkflowSlugConflictResponse.
+type WorkflowSlugConflictResponse struct {
+	Code    WorkflowSlugConflictResponseCode `json:"code"`
+	Details struct {
+		// ExistingWorkflowId UUID of the workflow that already uses this slug, if known.
+		ExistingWorkflowId *string `json:"existingWorkflowId,omitempty"`
+
+		// Slug The slug that collided.
+		Slug string `json:"slug"`
+	} `json:"details"`
+	Message string `json:"message"`
+}
+
+// WorkflowSlugConflictResponseCode defines model for WorkflowSlugConflictResponse.Code.
+type WorkflowSlugConflictResponseCode string
 
 // WorkflowStringInput defines model for WorkflowStringInput.
 type WorkflowStringInput struct {
@@ -1789,6 +1836,12 @@ type ListWorkflowsParams struct {
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
+// CreateWorkflowRunBySlugJSONBody defines parameters for CreateWorkflowRunBySlug.
+type CreateWorkflowRunBySlugJSONBody struct {
+	// Inputs Input values for the workflow run.
+	Inputs map[string]interface{} `json:"inputs"`
+}
+
 // CreateWorkflowRunJSONBody defines parameters for CreateWorkflowRun.
 type CreateWorkflowRunJSONBody struct {
 	// Inputs Input values for the workflow run.
@@ -1887,6 +1940,9 @@ type UpdateVariableSetJSONRequestBody = UpdateVariableSet
 
 // CreateWorkflowJSONRequestBody defines body for CreateWorkflow for application/json ContentType.
 type CreateWorkflowJSONRequestBody = CreateWorkflow
+
+// CreateWorkflowRunBySlugJSONRequestBody defines body for CreateWorkflowRunBySlug for application/json ContentType.
+type CreateWorkflowRunBySlugJSONRequestBody CreateWorkflowRunBySlugJSONBody
 
 // UpdateWorkflowJSONRequestBody defines body for UpdateWorkflow for application/json ContentType.
 type UpdateWorkflowJSONRequestBody = UpdateWorkflow
@@ -2933,6 +2989,14 @@ type ClientInterface interface {
 	CreateWorkflowWithBody(ctx context.Context, workspaceId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CreateWorkflow(ctx context.Context, workspaceId string, body CreateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetWorkflowBySlug request
+	GetWorkflowBySlug(ctx context.Context, workspaceId string, slug string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateWorkflowRunBySlugWithBody request with any body
+	CreateWorkflowRunBySlugWithBody(ctx context.Context, workspaceId string, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateWorkflowRunBySlug(ctx context.Context, workspaceId string, slug string, body CreateWorkflowRunBySlugJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteWorkflow request
 	DeleteWorkflow(ctx context.Context, workspaceId string, workflowId string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4393,6 +4457,42 @@ func (c *Client) CreateWorkflowWithBody(ctx context.Context, workspaceId string,
 
 func (c *Client) CreateWorkflow(ctx context.Context, workspaceId string, body CreateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCreateWorkflowRequest(c.Server, workspaceId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetWorkflowBySlug(ctx context.Context, workspaceId string, slug string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWorkflowBySlugRequest(c.Server, workspaceId, slug)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateWorkflowRunBySlugWithBody(ctx context.Context, workspaceId string, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateWorkflowRunBySlugRequestWithBody(c.Server, workspaceId, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateWorkflowRunBySlug(ctx context.Context, workspaceId string, slug string, body CreateWorkflowRunBySlugJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateWorkflowRunBySlugRequest(c.Server, workspaceId, slug, body)
 	if err != nil {
 		return nil, err
 	}
@@ -9183,6 +9283,101 @@ func NewCreateWorkflowRequestWithBody(server string, workspaceId string, content
 	return req, nil
 }
 
+// NewGetWorkflowBySlugRequest generates requests for GetWorkflowBySlug
+func NewGetWorkflowBySlugRequest(server string, workspaceId string, slug string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "workspaceId", runtime.ParamLocationPath, workspaceId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/workspaces/%s/workflows/slug/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateWorkflowRunBySlugRequest calls the generic CreateWorkflowRunBySlug builder with application/json body
+func NewCreateWorkflowRunBySlugRequest(server string, workspaceId string, slug string, body CreateWorkflowRunBySlugJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateWorkflowRunBySlugRequestWithBody(server, workspaceId, slug, "application/json", bodyReader)
+}
+
+// NewCreateWorkflowRunBySlugRequestWithBody generates requests for CreateWorkflowRunBySlug with any type of body
+func NewCreateWorkflowRunBySlugRequestWithBody(server string, workspaceId string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "workspaceId", runtime.ParamLocationPath, workspaceId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/workspaces/%s/workflows/slug/%s/runs", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewDeleteWorkflowRequest generates requests for DeleteWorkflow
 func NewDeleteWorkflowRequest(server string, workspaceId string, workflowId string) (*http.Request, error) {
 	var err error
@@ -9747,6 +9942,14 @@ type ClientWithResponsesInterface interface {
 	CreateWorkflowWithBodyWithResponse(ctx context.Context, workspaceId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateWorkflowResponse, error)
 
 	CreateWorkflowWithResponse(ctx context.Context, workspaceId string, body CreateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateWorkflowResponse, error)
+
+	// GetWorkflowBySlugWithResponse request
+	GetWorkflowBySlugWithResponse(ctx context.Context, workspaceId string, slug string, reqEditors ...RequestEditorFn) (*GetWorkflowBySlugResponse, error)
+
+	// CreateWorkflowRunBySlugWithBodyWithResponse request with any body
+	CreateWorkflowRunBySlugWithBodyWithResponse(ctx context.Context, workspaceId string, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateWorkflowRunBySlugResponse, error)
+
+	CreateWorkflowRunBySlugWithResponse(ctx context.Context, workspaceId string, slug string, body CreateWorkflowRunBySlugJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateWorkflowRunBySlugResponse, error)
 
 	// DeleteWorkflowWithResponse request
 	DeleteWorkflowWithResponse(ctx context.Context, workspaceId string, workflowId string, reqEditors ...RequestEditorFn) (*DeleteWorkflowResponse, error)
@@ -10394,7 +10597,7 @@ type ListDeploymentVersionsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		Items []DeploymentVersion `json:"items"`
+		Items []DeploymentVersionWithDependencies `json:"items"`
 
 		// Limit Maximum number of items returned
 		Limit int `json:"limit"`
@@ -12091,6 +12294,7 @@ type CreateWorkflowResponse struct {
 	HTTPResponse *http.Response
 	JSON201      *Workflow
 	JSON400      *ErrorResponse
+	JSON409      *WorkflowSlugConflictResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -12103,6 +12307,54 @@ func (r CreateWorkflowResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r CreateWorkflowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetWorkflowBySlugResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Workflow
+	JSON400      *ErrorResponse
+	JSON404      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetWorkflowBySlugResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetWorkflowBySlugResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateWorkflowRunBySlugResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *WorkflowRun
+	JSON400      *ErrorResponse
+	JSON404      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateWorkflowRunBySlugResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateWorkflowRunBySlugResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12163,6 +12415,7 @@ type UpdateWorkflowResponse struct {
 	JSON202      *Workflow
 	JSON400      *ErrorResponse
 	JSON404      *ErrorResponse
+	JSON409      *WorkflowSlugConflictResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -13261,6 +13514,32 @@ func (c *ClientWithResponses) CreateWorkflowWithResponse(ctx context.Context, wo
 		return nil, err
 	}
 	return ParseCreateWorkflowResponse(rsp)
+}
+
+// GetWorkflowBySlugWithResponse request returning *GetWorkflowBySlugResponse
+func (c *ClientWithResponses) GetWorkflowBySlugWithResponse(ctx context.Context, workspaceId string, slug string, reqEditors ...RequestEditorFn) (*GetWorkflowBySlugResponse, error) {
+	rsp, err := c.GetWorkflowBySlug(ctx, workspaceId, slug, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetWorkflowBySlugResponse(rsp)
+}
+
+// CreateWorkflowRunBySlugWithBodyWithResponse request with arbitrary body returning *CreateWorkflowRunBySlugResponse
+func (c *ClientWithResponses) CreateWorkflowRunBySlugWithBodyWithResponse(ctx context.Context, workspaceId string, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateWorkflowRunBySlugResponse, error) {
+	rsp, err := c.CreateWorkflowRunBySlugWithBody(ctx, workspaceId, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateWorkflowRunBySlugResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateWorkflowRunBySlugWithResponse(ctx context.Context, workspaceId string, slug string, body CreateWorkflowRunBySlugJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateWorkflowRunBySlugResponse, error) {
+	rsp, err := c.CreateWorkflowRunBySlug(ctx, workspaceId, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateWorkflowRunBySlugResponse(rsp)
 }
 
 // DeleteWorkflowWithResponse request returning *DeleteWorkflowResponse
@@ -14374,7 +14653,7 @@ func ParseListDeploymentVersionsResponse(rsp *http.Response) (*ListDeploymentVer
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			Items []DeploymentVersion `json:"items"`
+			Items []DeploymentVersionWithDependencies `json:"items"`
 
 			// Limit Maximum number of items returned
 			Limit int `json:"limit"`
@@ -16932,6 +17211,93 @@ func ParseCreateWorkflowResponse(rsp *http.Response) (*CreateWorkflowResponse, e
 		}
 		response.JSON400 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest WorkflowSlugConflictResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetWorkflowBySlugResponse parses an HTTP response from a GetWorkflowBySlugWithResponse call
+func ParseGetWorkflowBySlugResponse(rsp *http.Response) (*GetWorkflowBySlugResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetWorkflowBySlugResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Workflow
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateWorkflowRunBySlugResponse parses an HTTP response from a CreateWorkflowRunBySlugWithResponse call
+func ParseCreateWorkflowRunBySlugResponse(rsp *http.Response) (*CreateWorkflowRunBySlugResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateWorkflowRunBySlugResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest WorkflowRun
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
 	}
 
 	return response, nil
@@ -17051,6 +17417,13 @@ func ParseUpdateWorkflowResponse(rsp *http.Response) (*UpdateWorkflowResponse, e
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest WorkflowSlugConflictResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	}
 

--- a/internal/provider/workflow_resource.go
+++ b/internal/provider/workflow_resource.go
@@ -33,6 +33,7 @@ type WorkflowResource struct {
 type WorkflowResourceModel struct {
 	ID        types.String            `tfsdk:"id"`
 	Name      types.String            `tfsdk:"name"`
+	Slug      types.String            `tfsdk:"slug"`
 	Inputs    types.String            `tfsdk:"inputs"`
 	JobAgents []WorkflowJobAgentModel `tfsdk:"job_agent"`
 }
@@ -78,6 +79,14 @@ func (r *WorkflowResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "The name of the workflow.",
+			},
+			"slug": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "URL-safe identifier unique within the workspace. Derived from name if omitted; sticky once set.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"inputs": schema.StringAttribute{
 				Optional:    true,
@@ -128,6 +137,7 @@ func (r *WorkflowResource) Create(ctx context.Context, req resource.CreateReques
 
 	body := api.CreateWorkflowJSONRequestBody{
 		Name:      data.Name.ValueString(),
+		Slug:      optionalSlug(data.Slug),
 		Inputs:    inputs,
 		JobAgents: workflowJobAgentsFromModel(data.JobAgents),
 	}
@@ -198,6 +208,7 @@ func (r *WorkflowResource) Update(ctx context.Context, req resource.UpdateReques
 
 	body := api.UpdateWorkflowJSONRequestBody{
 		Name:      data.Name.ValueString(),
+		Slug:      optionalSlug(data.Slug),
 		Inputs:    inputs,
 		JobAgents: workflowJobAgentsFromModel(data.JobAgents),
 	}
@@ -305,9 +316,18 @@ func workflowJobAgentsFromModel(agents []WorkflowJobAgentModel) []api.CreateWork
 	return result
 }
 
+func optionalSlug(s types.String) *string {
+	if s.IsNull() || s.IsUnknown() {
+		return nil
+	}
+	v := s.ValueString()
+	return &v
+}
+
 func setWorkflowModelFromAPI(data *WorkflowResourceModel, w *api.Workflow) {
 	data.ID = types.StringValue(w.Id)
 	data.Name = types.StringValue(w.Name)
+	data.Slug = types.StringValue(w.Slug)
 
 	data.Inputs = types.StringValue(normalizeInputsJSON(w.Inputs))
 

--- a/internal/provider/workflow_resource_test.go
+++ b/internal/provider/workflow_resource_test.go
@@ -17,6 +17,8 @@ import (
 func TestAccWorkflowResource(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-wf-%d", time.Now().UnixNano())
 	updatedName := name + "-updated"
+	// name is already lowercase + digits + hyphens, so slugify is a no-op.
+	derivedSlug := name
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -35,6 +37,11 @@ func TestAccWorkflowResource(t *testing.T) {
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(name),
 					),
+					statecheck.ExpectKnownValue(
+						"ctrlplane_workflow.test",
+						tfjsonpath.New("slug"),
+						knownvalue.StringExact(derivedSlug),
+					),
 				},
 			},
 			{
@@ -44,6 +51,39 @@ func TestAccWorkflowResource(t *testing.T) {
 						"ctrlplane_workflow.test",
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(updatedName),
+					),
+					// Slug is sticky: renaming the workflow must NOT change the slug.
+					statecheck.ExpectKnownValue(
+						"ctrlplane_workflow.test",
+						tfjsonpath.New("slug"),
+						knownvalue.StringExact(derivedSlug),
+					),
+				},
+			},
+			{
+				ResourceName:      "ctrlplane_workflow.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccWorkflowResource_ExplicitSlug(t *testing.T) {
+	name := fmt.Sprintf("tf-acc-wf-explicit-%d", time.Now().UnixNano())
+	slug := fmt.Sprintf("custom-slug-%d", time.Now().UnixNano())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkflowConfigWithSlug(name, slug),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"ctrlplane_workflow.test",
+						tfjsonpath.New("slug"),
+						knownvalue.StringExact(slug),
 					),
 				},
 			},
@@ -80,4 +120,31 @@ resource "ctrlplane_workflow" "test" {
   }
 }
 `, testAccProviderConfig(), name+"-agent", name)
+}
+
+func testAccWorkflowConfigWithSlug(name, slug string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "ctrlplane_job_agent" "test" {
+  name = %q
+
+  test_runner {
+    delay_seconds = 5
+    status        = "successful"
+  }
+}
+
+resource "ctrlplane_workflow" "test" {
+  name = %q
+  slug = %q
+
+  job_agent {
+    name     = "test-agent"
+    ref      = ctrlplane_job_agent.test.id
+    config   = { "delaySeconds" = "5", "status" = "successful" }
+    selector = "true"
+  }
+}
+`, testAccProviderConfig(), name+"-agent", name, slug)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflows now support slug attributes, auto-derived from names and remaining sticky once set.
  * Added support for accessing and managing workflows by slug.
  * Deployment versions now include dependency information.
  * Added 409 conflict response handling for duplicate workflow slugs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ctrlplanedev/terraform-provider-ctrlplane/pull/57)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->